### PR TITLE
Fix JSS SSR

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,14 +1,8 @@
 import React from 'react'
 import 'normalize.css'
-import { ThemeProvider } from 'react-jss'
 
-import { theme } from './src/styles/theme'
 import { Layout } from './src/components/layout/layout.component'
 
 export const wrapPageElement = ({ element, props }) => {
   return <Layout {...props}>{element}</Layout>
-}
-
-export const wrapRootElement = ({ element }) => {
-  return <ThemeProvider theme={theme}>{element}</ThemeProvider>
 }

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,4 +1,4 @@
-// const path = require(`path`)
+const theme = require('./src/styles/theme.js')
 
 module.exports = {
   siteMetadata: {
@@ -7,6 +7,12 @@ module.exports = {
     siteUrl: process.env.GATSBY_SITE_URL
   },
   plugins: [
+    {
+      resolve: 'gatsby-plugin-jss',
+      options: {
+        theme
+      }
+    },
     {
       resolve: 'gatsby-plugin-react-svg',
       options: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7247,6 +7247,14 @@
         "micromatch": "^4.0.2"
       }
     },
+    "gatsby-plugin-jss": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-jss/-/gatsby-plugin-jss-2.7.0.tgz",
+      "integrity": "sha512-Nb3yERAv5YuFrDVaowT09LFUkYJYZkljk1cJMMLG/A912xtygI5iyS4caun4V9u3DnPm/stuCRW5BM7Od8lzjA==",
+      "requires": {
+        "@babel/runtime": "^7.12.5"
+      }
+    },
     "gatsby-plugin-page-creator": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-page-creator/-/gatsby-plugin-page-creator-2.7.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -108,25 +108,6 @@
         "@babel/types": "^7.10.4"
       }
     },
-    "@babel/helper-builder-react-jsx": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.10.4.tgz",
-      "integrity": "sha512-5nPcIZ7+KKDxT1427oBivl9V9YTal7qk0diccnh7RrcgrT/pGFOjgGw1dgryyx1GvHEpXVfoDF6Ak3rTiWh8Rg==",
-      "requires": {
-        "@babel/helper-annotate-as-pure": "^7.10.4",
-        "@babel/types": "^7.10.4"
-      }
-    },
-    "@babel/helper-builder-react-jsx-experimental": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx-experimental/-/helper-builder-react-jsx-experimental-7.12.11.tgz",
-      "integrity": "sha512-4oGVOekPI8dh9JphkPXC68iIuP6qp/RPbaPmorRmEFbRAHZjSqxPjqHudn18GVDPgCuFM/KdFXc63C17Ygfa9w==",
-      "requires": {
-        "@babel/helper-annotate-as-pure": "^7.12.10",
-        "@babel/helper-module-imports": "^7.12.5",
-        "@babel/types": "^7.12.11"
-      }
-    },
     "@babel/helper-compilation-targets": {
       "version": "7.12.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.12.5.tgz",
@@ -359,9 +340,9 @@
       "integrity": "sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg=="
     },
     "@babel/plugin-proposal-async-generator-functions": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.12.1.tgz",
-      "integrity": "sha512-d+/o30tJxFxrA1lhzJqiUcEJdI6jKlNregCv5bASeGf2Q4MXmnwH7viDo7nhx1/ohf09oaH8j1GVYG/e3Yqk6A==",
+      "version": "7.12.12",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.12.12.tgz",
+      "integrity": "sha512-nrz9y0a4xmUrRq51bYkWJIO5SBZyG2ys2qinHsN0zHDHVsUaModrkpyWWWXfGqYQmOL3x9sQIcTNN/pBGpo09A==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.10.4",
         "@babel/helper-remap-async-to-generator": "^7.12.1",
@@ -617,9 +598,9 @@
       }
     },
     "@babel/plugin-transform-block-scoping": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.12.11.tgz",
-      "integrity": "sha512-atR1Rxc3hM+VPg/NvNvfYw0npQEAcHuJ+MGZnFn6h3bo+1U3BWXMdFMlvVRApBTWKQMX7SOwRJZA5FBF/JQbvA==",
+      "version": "7.12.12",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.12.12.tgz",
+      "integrity": "sha512-VOEPQ/ExOVqbukuP7BYJtI5ZxxsmegTwzZ04j1aF0dkSypGo9XpDHuOrABsJu+ie+penpSJheDJ11x1BEZNiyQ==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.10.4"
       }
@@ -806,24 +787,23 @@
       }
     },
     "@babel/plugin-transform-react-jsx": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.12.11.tgz",
-      "integrity": "sha512-5nWOw6mTylaFU72BdZfa0dP1HsGdY3IMExpxn8LBE8dNmkQjB+W+sR+JwIdtbzkPvVuFviT3zyNbSUkuVTVxbw==",
+      "version": "7.12.12",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.12.12.tgz",
+      "integrity": "sha512-JDWGuzGNWscYcq8oJVCtSE61a5+XAOos+V0HrxnDieUus4UMnBEosDnY1VJqU5iZ4pA04QY7l0+JvHL1hZEfsw==",
       "requires": {
-        "@babel/helper-builder-react-jsx": "^7.10.4",
-        "@babel/helper-builder-react-jsx-experimental": "^7.12.11",
+        "@babel/helper-annotate-as-pure": "^7.12.10",
+        "@babel/helper-module-imports": "^7.12.5",
         "@babel/helper-plugin-utils": "^7.10.4",
-        "@babel/plugin-syntax-jsx": "^7.12.1"
+        "@babel/plugin-syntax-jsx": "^7.12.1",
+        "@babel/types": "^7.12.12"
       }
     },
     "@babel/plugin-transform-react-jsx-development": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.12.11.tgz",
-      "integrity": "sha512-5MvsGschXeXJsbzQGR/BH89ATMzCsM7rx95n+R7/852cGoK2JgMbacDw/A9Pmrfex4tArdMab0L5SBV4SB/Nxg==",
+      "version": "7.12.12",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.12.12.tgz",
+      "integrity": "sha512-i1AxnKxHeMxUaWVXQOSIco4tvVvvCxMSfeBMnMM06mpaJt3g+MpxYQQrDfojUQldP1xxraPSJYSMEljoWM/dCg==",
       "requires": {
-        "@babel/helper-builder-react-jsx-experimental": "^7.12.11",
-        "@babel/helper-plugin-utils": "^7.10.4",
-        "@babel/plugin-syntax-jsx": "^7.12.1"
+        "@babel/plugin-transform-react-jsx": "^7.12.12"
       }
     },
     "@babel/plugin-transform-react-pure-annotations": {
@@ -1068,9 +1048,9 @@
       }
     },
     "@babel/standalone": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/standalone/-/standalone-7.12.11.tgz",
-      "integrity": "sha512-z+iFopDt0/8PUB8D0p7+95wYgXisRX6xi64fXCkpIRbkrA0nCf8t4yBBkSQ5YW/o9jPmmNhmX13OqsirloqdKQ=="
+      "version": "7.12.12",
+      "resolved": "https://registry.npmjs.org/@babel/standalone/-/standalone-7.12.12.tgz",
+      "integrity": "sha512-sHuNDN9NvPHsDAmxPD3RpsIeqCoFSW+ySa6+3teInrYe9y0Gn5swLQ2ZE7Zk6L8eBBESZM2ob1l98qWauQfDMA=="
     },
     "@babel/template": {
       "version": "7.12.7",
@@ -1083,16 +1063,16 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.12.10",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.10.tgz",
-      "integrity": "sha512-6aEtf0IeRgbYWzta29lePeYSk+YAFIC3kyqESeft8o5CkFlYIMX+EQDDWEiAQ9LHOA3d0oHdgrSsID/CKqXJlg==",
+      "version": "7.12.12",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.12.tgz",
+      "integrity": "sha512-s88i0X0lPy45RrLM8b9mz8RPH5FqO9G9p7ti59cToE44xFm1Q+Pjh5Gq4SXBbtb88X7Uy7pexeqRIQDDMNkL0w==",
       "requires": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/generator": "^7.12.10",
-        "@babel/helper-function-name": "^7.10.4",
-        "@babel/helper-split-export-declaration": "^7.11.0",
-        "@babel/parser": "^7.12.10",
-        "@babel/types": "^7.12.10",
+        "@babel/code-frame": "^7.12.11",
+        "@babel/generator": "^7.12.11",
+        "@babel/helper-function-name": "^7.12.11",
+        "@babel/helper-split-export-declaration": "^7.12.11",
+        "@babel/parser": "^7.12.11",
+        "@babel/types": "^7.12.12",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
         "lodash": "^4.17.19"
@@ -1109,9 +1089,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.11.tgz",
-      "integrity": "sha512-ukA9SQtKThINm++CX1CwmliMrE54J6nIYB5XTwL5f/CLFW9owfls+YSU8tVW15RQ2w+a3fSbPjC6HdQNtWZkiA==",
+      "version": "7.12.12",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
+      "integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
       "requires": {
         "@babel/helper-validator-identifier": "^7.12.11",
         "lodash": "^4.17.19",
@@ -1161,9 +1141,9 @@
       },
       "dependencies": {
         "@graphql-tools/utils": {
-          "version": "7.1.5",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.1.5.tgz",
-          "integrity": "sha512-utJgoKJNhAUz0i+MGF1uvz7i4fxxz1TE21c68R38Hs4kmXO6A6H5e18jwzGdjspyf3IZOS621fmN9GQPzIazHg==",
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.2.3.tgz",
+          "integrity": "sha512-9MvSKeo+8DM72706FvrUP8figQjRzSwBswWrXviyWyt3wSkk6MU2cURQKfMpc0I6nswZvkDSqYoQQ/6mazoXxA==",
           "requires": {
             "@ardatan/aggregate-error": "0.0.6",
             "camel-case": "4.1.2",
@@ -1178,23 +1158,23 @@
       }
     },
     "@graphql-tools/delegate": {
-      "version": "7.0.7",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-7.0.7.tgz",
-      "integrity": "sha512-2sze+CJxu37b4jcQ4fyj6ap9TMnx8+NBtApSs1nWIVENzPE2510aNTsBHgSdTwSeV/tVIFkAtZZAlMEGYGXzQA==",
+      "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-7.0.8.tgz",
+      "integrity": "sha512-pS1wci7ZxzdCITRrMI66UA+6/E0Z1Yczd3QxJBDb4Kp0nTGy1xy7enGa0+i55EmCvKvuwyx+tzXzwA1fNGRJzg==",
       "requires": {
         "@ardatan/aggregate-error": "0.0.6",
         "@graphql-tools/batch-execute": "^7.0.0",
         "@graphql-tools/schema": "^7.0.0",
-        "@graphql-tools/utils": "^7.0.2",
+        "@graphql-tools/utils": "^7.1.6",
         "dataloader": "2.0.0",
         "is-promise": "4.0.0",
         "tslib": "~2.0.1"
       },
       "dependencies": {
         "@graphql-tools/utils": {
-          "version": "7.1.5",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.1.5.tgz",
-          "integrity": "sha512-utJgoKJNhAUz0i+MGF1uvz7i4fxxz1TE21c68R38Hs4kmXO6A6H5e18jwzGdjspyf3IZOS621fmN9GQPzIazHg==",
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.2.3.tgz",
+          "integrity": "sha512-9MvSKeo+8DM72706FvrUP8figQjRzSwBswWrXviyWyt3wSkk6MU2cURQKfMpc0I6nswZvkDSqYoQQ/6mazoXxA==",
           "requires": {
             "@ardatan/aggregate-error": "0.0.6",
             "camel-case": "4.1.2",
@@ -1219,9 +1199,9 @@
       },
       "dependencies": {
         "@graphql-tools/utils": {
-          "version": "7.1.5",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.1.5.tgz",
-          "integrity": "sha512-utJgoKJNhAUz0i+MGF1uvz7i4fxxz1TE21c68R38Hs4kmXO6A6H5e18jwzGdjspyf3IZOS621fmN9GQPzIazHg==",
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.2.3.tgz",
+          "integrity": "sha512-9MvSKeo+8DM72706FvrUP8figQjRzSwBswWrXviyWyt3wSkk6MU2cURQKfMpc0I6nswZvkDSqYoQQ/6mazoXxA==",
           "requires": {
             "@ardatan/aggregate-error": "0.0.6",
             "camel-case": "4.1.2",
@@ -1266,9 +1246,9 @@
       },
       "dependencies": {
         "@graphql-tools/utils": {
-          "version": "7.1.5",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.1.5.tgz",
-          "integrity": "sha512-utJgoKJNhAUz0i+MGF1uvz7i4fxxz1TE21c68R38Hs4kmXO6A6H5e18jwzGdjspyf3IZOS621fmN9GQPzIazHg==",
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.2.3.tgz",
+          "integrity": "sha512-9MvSKeo+8DM72706FvrUP8figQjRzSwBswWrXviyWyt3wSkk6MU2cURQKfMpc0I6nswZvkDSqYoQQ/6mazoXxA==",
           "requires": {
             "@ardatan/aggregate-error": "0.0.6",
             "camel-case": "4.1.2",
@@ -1299,9 +1279,9 @@
       },
       "dependencies": {
         "@graphql-tools/utils": {
-          "version": "7.1.5",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.1.5.tgz",
-          "integrity": "sha512-utJgoKJNhAUz0i+MGF1uvz7i4fxxz1TE21c68R38Hs4kmXO6A6H5e18jwzGdjspyf3IZOS621fmN9GQPzIazHg==",
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.2.3.tgz",
+          "integrity": "sha512-9MvSKeo+8DM72706FvrUP8figQjRzSwBswWrXviyWyt3wSkk6MU2cURQKfMpc0I6nswZvkDSqYoQQ/6mazoXxA==",
           "requires": {
             "@ardatan/aggregate-error": "0.0.6",
             "camel-case": "4.1.2",
@@ -1347,9 +1327,9 @@
       },
       "dependencies": {
         "@graphql-tools/utils": {
-          "version": "7.1.5",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.1.5.tgz",
-          "integrity": "sha512-utJgoKJNhAUz0i+MGF1uvz7i4fxxz1TE21c68R38Hs4kmXO6A6H5e18jwzGdjspyf3IZOS621fmN9GQPzIazHg==",
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.2.3.tgz",
+          "integrity": "sha512-9MvSKeo+8DM72706FvrUP8figQjRzSwBswWrXviyWyt3wSkk6MU2cURQKfMpc0I6nswZvkDSqYoQQ/6mazoXxA==",
           "requires": {
             "@ardatan/aggregate-error": "0.0.6",
             "camel-case": "4.1.2",
@@ -1373,9 +1353,9 @@
       },
       "dependencies": {
         "@graphql-tools/utils": {
-          "version": "7.1.5",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.1.5.tgz",
-          "integrity": "sha512-utJgoKJNhAUz0i+MGF1uvz7i4fxxz1TE21c68R38Hs4kmXO6A6H5e18jwzGdjspyf3IZOS621fmN9GQPzIazHg==",
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.2.3.tgz",
+          "integrity": "sha512-9MvSKeo+8DM72706FvrUP8figQjRzSwBswWrXviyWyt3wSkk6MU2cURQKfMpc0I6nswZvkDSqYoQQ/6mazoXxA==",
           "requires": {
             "@ardatan/aggregate-error": "0.0.6",
             "camel-case": "4.1.2",
@@ -1414,9 +1394,9 @@
       },
       "dependencies": {
         "@graphql-tools/utils": {
-          "version": "7.1.5",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.1.5.tgz",
-          "integrity": "sha512-utJgoKJNhAUz0i+MGF1uvz7i4fxxz1TE21c68R38Hs4kmXO6A6H5e18jwzGdjspyf3IZOS621fmN9GQPzIazHg==",
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.2.3.tgz",
+          "integrity": "sha512-9MvSKeo+8DM72706FvrUP8figQjRzSwBswWrXviyWyt3wSkk6MU2cURQKfMpc0I6nswZvkDSqYoQQ/6mazoXxA==",
           "requires": {
             "@ardatan/aggregate-error": "0.0.6",
             "camel-case": "4.1.2",
@@ -1464,21 +1444,21 @@
       }
     },
     "@graphql-tools/wrap": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-7.0.4.tgz",
-      "integrity": "sha512-txBs0W4k3WR86aEzBYXtKdGeeUXCNdRNxjQA/95T6ywNYoM8pw2mvpoXrWOvzbeaH3zwhbHY7kwii4atrC9irg==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-7.0.5.tgz",
+      "integrity": "sha512-KCWBXsDfvG46GNUawRltJL4j9BMGoOG7oo3WEyCQP+SByWXiTe5cBF45SLDVQgdjljGNZhZ4Lq/7avIkF7/zDQ==",
       "requires": {
         "@graphql-tools/delegate": "^7.0.7",
         "@graphql-tools/schema": "^7.1.2",
-        "@graphql-tools/utils": "^7.1.4",
+        "@graphql-tools/utils": "^7.2.1",
         "is-promise": "4.0.0",
         "tslib": "~2.0.1"
       },
       "dependencies": {
         "@graphql-tools/utils": {
-          "version": "7.1.5",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.1.5.tgz",
-          "integrity": "sha512-utJgoKJNhAUz0i+MGF1uvz7i4fxxz1TE21c68R38Hs4kmXO6A6H5e18jwzGdjspyf3IZOS621fmN9GQPzIazHg==",
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.2.3.tgz",
+          "integrity": "sha512-9MvSKeo+8DM72706FvrUP8figQjRzSwBswWrXviyWyt3wSkk6MU2cURQKfMpc0I6nswZvkDSqYoQQ/6mazoXxA==",
           "requires": {
             "@ardatan/aggregate-error": "0.0.6",
             "camel-case": "4.1.2",
@@ -1598,25 +1578,25 @@
       "integrity": "sha512-6cDuZeKSCSJ1KvfEQ25Y8OXUjqDJZ+HgUs6dhASWbAX8fxVraTfPsSeRe2bN+4QJDsgUaXaMWBYfRomCr04GGg=="
     },
     "@nodelib/fs.scandir": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
-      "integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz",
+      "integrity": "sha512-33g3pMJk3bg5nXbL/+CY6I2eJDzZAni49PfJnL5fghPTggPvBd/pFNSgJsdAgWptuFu7qq/ERvOYFlhvsLTCKA==",
       "requires": {
-        "@nodelib/fs.stat": "2.0.3",
+        "@nodelib/fs.stat": "2.0.4",
         "run-parallel": "^1.1.9"
       }
     },
     "@nodelib/fs.stat": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
-      "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA=="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz",
+      "integrity": "sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q=="
     },
     "@nodelib/fs.walk": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
-      "integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.6.tgz",
+      "integrity": "sha512-8Broas6vTtW4GIXTAHDoE32hnN2M5ykgCpWGbuXHQ15vEMqr23pB76e/GZcYsZCHALv50ktd24qhEyKr6wBtow==",
       "requires": {
-        "@nodelib/fs.scandir": "2.1.3",
+        "@nodelib/fs.scandir": "2.1.4",
         "fastq": "^1.6.0"
       }
     },
@@ -1689,9 +1669,9 @@
       },
       "dependencies": {
         "@hapi/hoek": {
-          "version": "9.1.0",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.0.tgz",
-          "integrity": "sha512-i9YbZPN3QgfighY/1X1Pu118VUz2Fmmhd6b2n0/O8YVgGGfw0FbUYoA97k7FkpGJ+pLCFEDLUmAPPV4D1kpeFw=="
+          "version": "9.1.1",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.1.tgz",
+          "integrity": "sha512-CAEbWH7OIur6jEOzaai83jq3FmKmv4PmX1JYfs9IrYcGEVI/lyL1EXJGCj7eFVJ0bg5QR8LMxBlEtA+xKiLpFw=="
         }
       }
     },
@@ -1848,9 +1828,9 @@
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
     },
     "@types/lodash": {
-      "version": "4.14.165",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.165.tgz",
-      "integrity": "sha512-tjSSOTHhI5mCHTy/OOXYIhi2Wt1qcbHmuXD1Ha7q70CgI/I71afO4XtLb/cVexki1oVYchpul/TOuu3Arcdxrg=="
+      "version": "4.14.166",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.166.tgz",
+      "integrity": "sha512-A3YT/c1oTlyvvW/GQqG86EyqWNrT/tisOIh2mW3YCgcx71TNjiTZA3zYZWA5BCmtsOTXjhliy4c4yEkErw6njA=="
     },
     "@types/minimatch": {
       "version": "3.0.3",
@@ -1866,9 +1846,9 @@
       }
     },
     "@types/node": {
-      "version": "14.14.14",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.14.tgz",
-      "integrity": "sha512-UHnOPWVWV1z+VV8k6L1HhG7UbGBgIdghqF3l9Ny9ApPghbjICXkUJSd/b9gOgQfjM1r+37cipdw/HJ3F6ICEnQ=="
+      "version": "14.14.16",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.16.tgz",
+      "integrity": "sha512-naXYePhweTi+BMv11TgioE2/FXU4fSl29HAH1ffxVciNsH3rYXjNP2yM8wqmSm7jS20gM8TIklKiTen+1iVncw=="
     },
     "@types/node-fetch": {
       "version": "2.5.7",
@@ -1960,9 +1940,9 @@
       }
     },
     "@types/yargs-parser": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-15.0.0.tgz",
-      "integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw=="
+      "version": "20.2.0",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.0.tgz",
+      "integrity": "sha512-37RSHht+gzzgYeobbG+KWryeAW8J33Nhr69cjTqSYymXVZEN9NbRYWoYlRtDhHKPVT1FyNKwaTPC1NynKZpzRA=="
     },
     "@types/yoga-layout": {
       "version": "1.9.2",
@@ -2779,9 +2759,9 @@
       "integrity": "sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA=="
     },
     "babel-preset-gatsby": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-gatsby/-/babel-preset-gatsby-0.9.0.tgz",
-      "integrity": "sha512-nYVbydGWnVDnSUX4IPz1QCbwuL1Xfw+25p/rwyDtYntbtLyON3Klrn3jDeZB8EMts2EoTV9OLrP0G36GT0QQog==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-gatsby/-/babel-preset-gatsby-0.9.1.tgz",
+      "integrity": "sha512-J/2e5qn6G0Sn1YF1MGOMfYJrgaKAEUXbr52v06Y24buHdj52HUcftF8/xspSpBADLP/0MHt053AHFOOJvA9BzA==",
       "requires": {
         "@babel/plugin-proposal-class-properties": "^7.12.1",
         "@babel/plugin-proposal-nullish-coalescing-operator": "^7.12.1",
@@ -2795,7 +2775,7 @@
         "babel-plugin-dynamic-import-node": "^2.3.3",
         "babel-plugin-macros": "^2.8.0",
         "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
-        "gatsby-core-utils": "^1.7.0",
+        "gatsby-core-utils": "^1.7.1",
         "gatsby-legacy-polyfills": "^0.4.0"
       }
     },
@@ -3299,9 +3279,9 @@
       "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
     },
     "builtin-modules": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.1.0.tgz",
-      "integrity": "sha512-k0KL0aWZuBt2lrxrcASWDfwOLMnodeQjodT/1SxEQAXsHANgo6ZC/VEaSEHCXt7aSTZ4/4H5LKa+tBXmW7Vtvw=="
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.2.0.tgz",
+      "integrity": "sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA=="
     },
     "builtin-status-codes": {
       "version": "3.0.0",
@@ -3512,9 +3492,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001168",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001168.tgz",
-      "integrity": "sha512-P2zmX7swIXKu+GMMR01TWa4csIKELTNnZKc+f1CjebmZJQtTAEXmpQSoKVJVVcvPGAA0TEYTOUp3VehavZSFPQ=="
+      "version": "1.0.30001171",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001171.tgz",
+      "integrity": "sha512-5Alrh8TTYPG9IH4UkRqEBZoEToWRLvPbSQokvzSz0lii8/FOWKG4keO1HoYfPWs8IF/NH/dyNPg1cmJGvV3Zlg=="
     },
     "ccount": {
       "version": "1.1.0",
@@ -4395,9 +4375,9 @@
       }
     },
     "create-gatsby": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/create-gatsby/-/create-gatsby-0.2.0.tgz",
-      "integrity": "sha512-1KGKbAzY442rwmZ67rt2660l79n+qoKl2EjS3rcTzMkIBEpZ/+1DKDRaryeaZvEF7gWPV7viXxt+nQrniLgVpQ=="
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/create-gatsby/-/create-gatsby-0.2.1.tgz",
+      "integrity": "sha512-TYg5jfi97GWCuotU2otZUqNtNBmjIZTHlW1RE49JDK/QujtJ4pur9cp7oFJm9QaOqeiH+oq1/LK7JFzq9B44HA=="
     },
     "create-hash": {
       "version": "1.2.0",
@@ -5299,9 +5279,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron-to-chromium": {
-      "version": "1.3.627",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.627.tgz",
-      "integrity": "sha512-O5IVRS4sCxP2+vECAp7uHkaI8V+dKYpuCyBcLn+hqVAOy/RONd8zx+6eH7TuWSTBYs/oUrzBXkNMZuVsQd58kQ=="
+      "version": "1.3.633",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.633.tgz",
+      "integrity": "sha512-bsVCsONiVX1abkWdH7KtpuDAhsQ3N3bjPYhROSAXE78roJKet0Y5wznA14JE9pzbwSZmSMAW6KiKYf1RvbTJkA=="
     },
     "elliptic": {
       "version": "6.5.3",
@@ -5960,9 +5940,9 @@
       "dev": true
     },
     "eslint-plugin-react": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.21.5.tgz",
-      "integrity": "sha512-8MaEggC2et0wSF6bUeywF7qQ46ER81irOdWS4QWxnnlAEsnzeBevk1sWh7fhpCghPpXb+8Ks7hvaft6L/xsR6g==",
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.22.0.tgz",
+      "integrity": "sha512-p30tuX3VS+NWv9nQot9xIGAHBXR0+xJVaZriEsHoJrASGCJZDJ8JLNM0YqKqI0AKm6Uxaa1VUHoNEibxRCMQHA==",
       "requires": {
         "array-includes": "^3.1.1",
         "array.prototype.flatmap": "^1.2.3",
@@ -6493,9 +6473,9 @@
       "integrity": "sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ=="
     },
     "fastq": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.9.0.tgz",
-      "integrity": "sha512-i7FVWL8HhVY+CTkwFxkN2mk3h+787ixS5S63eb78diVRc1MCssarHq3W5cj0av7YDSwmaV928RNag+U1etRQ7w==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.10.0.tgz",
+      "integrity": "sha512-NL2Qc5L3iQEsyYzweq7qfgy5OtXCmGzGvhElGEd/SoFWEMOEczNh5s5ocaF01HDetxz+p8ecjNPA6cZxxIHmzA==",
       "requires": {
         "reusify": "^1.0.4"
       }
@@ -6795,9 +6775,9 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
     },
     "gatsby": {
-      "version": "2.29.0",
-      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-2.29.0.tgz",
-      "integrity": "sha512-sS1t1POQ0orRiQXNcZrcOa5fi++nRymXEENpfFTp8N9FDmBWH1EVUhXuEwKKtVIMdfm+Fhnt5TiBeZCDXRQyfQ==",
+      "version": "2.29.3",
+      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-2.29.3.tgz",
+      "integrity": "sha512-hcQwvor43T+7KU5gYsRz0B54kAkq0Bglcn/igMD8sJaaNxm9vIC86SLi0PLPMPr444H6A+h8X9Of60ZrmxPHBw==",
       "requires": {
         "@babel/code-frame": "^7.10.4",
         "@babel/core": "^7.12.3",
@@ -6826,7 +6806,7 @@
         "babel-plugin-dynamic-import-node": "^2.3.3",
         "babel-plugin-lodash": "3.3.4",
         "babel-plugin-remove-graphql-queries": "^2.13.0",
-        "babel-preset-gatsby": "^0.9.0",
+        "babel-preset-gatsby": "^0.9.1",
         "better-opn": "^2.0.0",
         "better-queue": "^3.8.10",
         "bluebird": "^3.7.2",
@@ -6866,16 +6846,16 @@
         "find-cache-dir": "^3.3.1",
         "fs-exists-cached": "1.0.0",
         "fs-extra": "^8.1.0",
-        "gatsby-cli": "^2.16.0",
-        "gatsby-core-utils": "^1.7.0",
+        "gatsby-cli": "^2.16.2",
+        "gatsby-core-utils": "^1.7.1",
         "gatsby-graphiql-explorer": "^0.8.0",
         "gatsby-legacy-polyfills": "^0.4.0",
         "gatsby-link": "^2.8.0",
-        "gatsby-plugin-page-creator": "^2.7.0",
+        "gatsby-plugin-page-creator": "^2.7.2",
         "gatsby-plugin-typescript": "^2.9.0",
         "gatsby-plugin-utils": "^0.6.0",
         "gatsby-react-router-scroll": "^3.4.0",
-        "gatsby-telemetry": "^1.7.0",
+        "gatsby-telemetry": "^1.7.1",
         "glob": "^7.1.6",
         "got": "8.3.2",
         "graphql": "^14.6.0",
@@ -7011,9 +6991,9 @@
           }
         },
         "gatsby-cli": {
-          "version": "2.16.0",
-          "resolved": "https://registry.npmjs.org/gatsby-cli/-/gatsby-cli-2.16.0.tgz",
-          "integrity": "sha512-WoFDKdHJ/Zrq74673zuaLrly9/LMGYWX6sIDxI6VHsgyeE1UFxYwOazx9uArjWZ4b3zFV3T2QYVZF6QuFbkeZg==",
+          "version": "2.16.2",
+          "resolved": "https://registry.npmjs.org/gatsby-cli/-/gatsby-cli-2.16.2.tgz",
+          "integrity": "sha512-YRnxrAl3mTyMghzf56DgusOrttzFZtv36Zk/Srd1Lrhk/bpCRKTNYAqbVvmv0yivjQhkyyE7aAbUTK19DapHPw==",
           "requires": {
             "@babel/code-frame": "^7.10.4",
             "@hapi/joi": "^15.1.1",
@@ -7024,14 +7004,14 @@
             "common-tags": "^1.8.0",
             "configstore": "^5.0.1",
             "convert-hrtime": "^3.0.0",
-            "create-gatsby": "^0.2.0",
+            "create-gatsby": "^0.2.1",
             "envinfo": "^7.7.3",
             "execa": "^3.4.0",
             "fs-exists-cached": "^1.0.0",
             "fs-extra": "^8.1.0",
-            "gatsby-core-utils": "^1.7.0",
-            "gatsby-recipes": "^0.6.0",
-            "gatsby-telemetry": "^1.7.0",
+            "gatsby-core-utils": "^1.7.1",
+            "gatsby-recipes": "^0.6.1",
+            "gatsby-telemetry": "^1.7.1",
             "hosted-git-info": "^3.0.6",
             "is-valid-path": "^0.1.1",
             "lodash": "^4.17.20",
@@ -7193,9 +7173,9 @@
       }
     },
     "gatsby-core-utils": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-1.7.0.tgz",
-      "integrity": "sha512-DYYkmlgpfkQBuc/vWEkSmp1xh7LGI00HA0AzH2U8AblrqAff3JBezeS3v8thkeuOm7FhlwkZGPNza+PIHYcwKA==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-1.7.1.tgz",
+      "integrity": "sha512-hnzQCixp2C4opmSgjido/CQwSt4FL3CcmGwq6fK3PVPTT3hLPz7rvuTMQIUlR8BJjGYai6i5f6V3wfkCJ3VTgQ==",
       "requires": {
         "ci-info": "2.0.0",
         "configstore": "^5.0.1",
@@ -7233,15 +7213,15 @@
       }
     },
     "gatsby-page-utils": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/gatsby-page-utils/-/gatsby-page-utils-0.6.0.tgz",
-      "integrity": "sha512-DG1uFBdru3Lvvp13HsDIgssbeNaO9ydirEu5OO4s6BiYHnropABEkjFow2FXJ6D451fm4i+KFI1JbVtKOiu8qg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/gatsby-page-utils/-/gatsby-page-utils-0.6.1.tgz",
+      "integrity": "sha512-ELEYcRpVDFeuDyt9E4zCtrWITTabPfBK3P4whwwUzvyzGefuv4W/16DaT93PPqhM5TOlGubQdJ7nhIngUu82ig==",
       "requires": {
         "@babel/runtime": "^7.12.5",
         "bluebird": "^3.7.2",
         "chokidar": "^3.4.3",
         "fs-exists-cached": "^1.0.0",
-        "gatsby-core-utils": "^1.7.0",
+        "gatsby-core-utils": "^1.7.1",
         "glob": "^7.1.6",
         "lodash": "^4.17.20",
         "micromatch": "^4.0.2"
@@ -7256,15 +7236,16 @@
       }
     },
     "gatsby-plugin-page-creator": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-page-creator/-/gatsby-plugin-page-creator-2.7.0.tgz",
-      "integrity": "sha512-lLUiwVGP/KfdlLwI7sB5naODK9KauPqPg9vd35LGKu/xI4izAi1070LwrG69XWm+R3RUF7NEkgHczBjwSI/fcQ==",
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-page-creator/-/gatsby-plugin-page-creator-2.7.2.tgz",
+      "integrity": "sha512-PyiimFUDMYHYbThkyYc2inKvDEcTR3zeDst/9Oq4IlyG7iL96esSWI/VLYTwHbcajYeUUQgTuUcVoT51mloF8A==",
       "requires": {
         "@babel/traverse": "^7.12.5",
         "@sindresorhus/slugify": "^1.1.0",
         "chokidar": "^3.4.2",
         "fs-exists-cached": "^1.0.0",
-        "gatsby-page-utils": "^0.6.0",
+        "gatsby-page-utils": "^0.6.1",
+        "gatsby-telemetry": "^1.7.1",
         "globby": "^11.0.1",
         "lodash": "^4.17.20"
       },
@@ -7323,9 +7304,9 @@
       }
     },
     "gatsby-recipes": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/gatsby-recipes/-/gatsby-recipes-0.6.0.tgz",
-      "integrity": "sha512-YH1BFCbuMNuvfw/3+DbQk5GDVNnz+1eVNdaBtE8Fo/Sa7rAfuezHnGtaa2CASI3V7ZKI3D1U6HnhQNULlfSa7g==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/gatsby-recipes/-/gatsby-recipes-0.6.1.tgz",
+      "integrity": "sha512-yuccPEl2LE4MA+jG4h5sNiNJQnTqK2uXbTytuq0erUreT7SipdsmpbvAcooJYmijGRm0iyzf763fkNB1MEPEkw==",
       "requires": {
         "@babel/core": "^7.12.3",
         "@babel/generator": "^7.12.5",
@@ -7350,8 +7331,8 @@
         "express": "^4.17.1",
         "express-graphql": "^0.9.0",
         "fs-extra": "^8.1.0",
-        "gatsby-core-utils": "^1.7.0",
-        "gatsby-telemetry": "^1.7.0",
+        "gatsby-core-utils": "^1.7.1",
+        "gatsby-telemetry": "^1.7.1",
         "glob": "^7.1.6",
         "graphql": "^14.6.0",
         "graphql-compose": "^6.3.8",
@@ -7388,9 +7369,9 @@
       },
       "dependencies": {
         "@graphql-tools/utils": {
-          "version": "7.1.5",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.1.5.tgz",
-          "integrity": "sha512-utJgoKJNhAUz0i+MGF1uvz7i4fxxz1TE21c68R38Hs4kmXO6A6H5e18jwzGdjspyf3IZOS621fmN9GQPzIazHg==",
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.2.3.tgz",
+          "integrity": "sha512-9MvSKeo+8DM72706FvrUP8figQjRzSwBswWrXviyWyt3wSkk6MU2cURQKfMpc0I6nswZvkDSqYoQQ/6mazoXxA==",
           "requires": {
             "@ardatan/aggregate-error": "0.0.6",
             "camel-case": "4.1.2",
@@ -7444,9 +7425,9 @@
       }
     },
     "gatsby-telemetry": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/gatsby-telemetry/-/gatsby-telemetry-1.7.0.tgz",
-      "integrity": "sha512-0hHskxnPV667snd6uSkZ32vKfBsv+9mFe0Pl3A9c9NC4HoKQlfmoluUTZr0nOjWdMMslz08XydzqxNdb6wB+oQ==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/gatsby-telemetry/-/gatsby-telemetry-1.7.1.tgz",
+      "integrity": "sha512-kLIjpspvnoCD7+5ybAv5uc/zc4NK8EMwlKEBHPxx7RJBEK220deD1ixtNEcO7nsDwH0Y+eE8Yom8qOPbr0F6Mw==",
       "requires": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -7456,7 +7437,7 @@
         "boxen": "^4.2.0",
         "configstore": "^5.0.1",
         "fs-extra": "^8.1.0",
-        "gatsby-core-utils": "^1.7.0",
+        "gatsby-core-utils": "^1.7.1",
         "git-up": "^4.0.2",
         "is-docker": "^2.1.1",
         "lodash": "^4.17.20",
@@ -7475,9 +7456,9 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
     "get-intrinsic": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.1.tgz",
-      "integrity": "sha512-ZnWP+AmS1VUaLgTRy47+zKtjTxz+0xMpx3I52i+aalBK1QP19ggLF3Db89KJX7kjfOfP2eoa01qc++GwPgufPg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.2.tgz",
+      "integrity": "sha512-aeX0vrFm21ILl3+JpFFRNe9aUvp6VFZb2/CTbgLb8j75kOhvoNYjt9d8KA/tJG4gSo8nzEDedRl0h7vDmBYRVg==",
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -8085,9 +8066,9 @@
       "integrity": "sha512-P+M65QY2JQ5Y0G9KKdlDpo0zK+/OHptU5AaBwUfAIDJZk1MYf32Frm84EcOytfJE0t5JvkAnKlmjsXDnWzCJmQ=="
     },
     "html-entities": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.3.3.tgz",
-      "integrity": "sha512-/VulV3SYni1taM7a4RMdceqzJWR39gpZHjBwUnsCFKWV/GJkD14CJ5F7eWcZozmHJK0/f/H5U3b3SiPkuvxMgg=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.4.0.tgz",
+      "integrity": "sha512-8nxjcBcd8wovbeKx7h3wTji4e6+rhaVuPNpMqwWgnHh+N9ToqsCs6XztWRBPQ+UtzsoMAdKZtUENoVzU/EMtZA=="
     },
     "htmlparser2": {
       "version": "3.10.1",
@@ -8331,9 +8312,9 @@
       }
     },
     "import-fresh": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.2.tgz",
-      "integrity": "sha512-cTPNrlvJT6twpYy+YmKUKrTSjWFs3bjYjAhCwm+z4EOCubZxAuO+hHpRN64TqjEaYSHs7tJAE0w1CKMGmsG/lw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
       "requires": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -9194,9 +9175,9 @@
       },
       "dependencies": {
         "@hapi/hoek": {
-          "version": "9.1.0",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.0.tgz",
-          "integrity": "sha512-i9YbZPN3QgfighY/1X1Pu118VUz2Fmmhd6b2n0/O8YVgGGfw0FbUYoA97k7FkpGJ+pLCFEDLUmAPPV4D1kpeFw=="
+          "version": "9.1.1",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.1.tgz",
+          "integrity": "sha512-CAEbWH7OIur6jEOzaai83jq3FmKmv4PmX1JYfs9IrYcGEVI/lyL1EXJGCj7eFVJ0bg5QR8LMxBlEtA+xKiLpFw=="
         },
         "@hapi/topo": {
           "version": "5.0.0",
@@ -9438,12 +9419,12 @@
       }
     },
     "jsx-ast-utils": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.1.0.tgz",
-      "integrity": "sha512-d4/UOjg+mxAWxCiF0c5UTSwyqbchkbqCvK87aBovhnh8GtysTjWmgC63tY0cJx/HzGgm9qnA147jVBdpOiQ2RA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.2.0.tgz",
+      "integrity": "sha512-EIsmt3O3ljsU6sot/J4E1zDRxfBNrhjyf/OKjlydwgEimQuznlM4Wv7U+ueONJMyEn1WRE0K8dhi3dVAXYT24Q==",
       "requires": {
-        "array-includes": "^3.1.1",
-        "object.assign": "^4.1.1"
+        "array-includes": "^3.1.2",
+        "object.assign": "^4.1.2"
       }
     },
     "keyv": {
@@ -12278,9 +12259,9 @@
       "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
     },
     "query-string": {
-      "version": "6.13.7",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.7.tgz",
-      "integrity": "sha512-CsGs8ZYb39zu0WLkeOhe0NMePqgYdAuCqxOYKDR5LVCytDZYMGx3Bb+xypvQvPHVPijRXB0HZNFllCzHRe4gEA==",
+      "version": "6.13.8",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.8.tgz",
+      "integrity": "sha512-jxJzQI2edQPE/NPUOusNjO/ZOGqr1o2OBa/3M00fU76FsLXDVbJDv/p7ng5OdQyorKrkRz1oqfwmbe5MAMePQg==",
       "requires": {
         "decode-uri-component": "^0.2.0",
         "split-on-first": "^1.0.0",
@@ -13644,12 +13625,13 @@
       }
     },
     "side-channel": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.3.tgz",
-      "integrity": "sha512-A6+ByhlLkksFoUepsGxfj5x1gTSrs+OydsRptUxeNCabQpCFUvcwIczgOigI8vhY/OJCnPnyE9rGiwgvr9cS1g==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
       "requires": {
-        "es-abstract": "^1.18.0-next.0",
-        "object-inspect": "^1.8.0"
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
       }
     },
     "signal-exit": {
@@ -13955,31 +13937,13 @@
       }
     },
     "sockjs": {
-      "version": "0.3.20",
-      "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.20.tgz",
-      "integrity": "sha512-SpmVOVpdq0DJc0qArhF3E5xsxvaiqGNb73XfgBpK1y3UD5gs8DSo8aCTsuT5pX8rssdc2NDIzANwP9eCAiSdTA==",
+      "version": "0.3.21",
+      "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.21.tgz",
+      "integrity": "sha512-DhbPFGpxjc6Z3I+uX07Id5ZO2XwYsWOrYjaSeieES78cq+JaJvVe5q/m1uvjIQhXinhIeCFRH6JgXe+mvVMyXw==",
       "requires": {
-        "faye-websocket": "^0.10.0",
+        "faye-websocket": "^0.11.3",
         "uuid": "^3.4.0",
-        "websocket-driver": "0.6.5"
-      },
-      "dependencies": {
-        "faye-websocket": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
-          "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
-          "requires": {
-            "websocket-driver": ">=0.5.1"
-          }
-        },
-        "websocket-driver": {
-          "version": "0.6.5",
-          "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz",
-          "integrity": "sha1-XLJVbOuF9Dc8bYI4qmkchFThOjY=",
-          "requires": {
-            "websocket-extensions": ">=0.1.1"
-          }
-        }
+        "websocket-driver": "^0.7.4"
       }
     },
     "sockjs-client": {
@@ -15914,9 +15878,9 @@
       }
     },
     "webpack-dev-server": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.11.0.tgz",
-      "integrity": "sha512-PUxZ+oSTxogFQgkTtFndEtJIPNmml7ExwufBZ9L2/Xyyd5PnOL5UreWe5ZT7IU25DSdykL9p1MLQzmLh2ljSeg==",
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.11.1.tgz",
+      "integrity": "sha512-u4R3mRzZkbxQVa+MBWi2uVpB5W59H3ekZAJsQlKUTdl7Elcah2EhygTPLmeFXybQkf9i2+L0kn7ik9SnXa6ihQ==",
       "requires": {
         "ansi-html": "0.0.7",
         "bonjour": "^3.5.0",
@@ -15938,11 +15902,11 @@
         "p-retry": "^3.0.1",
         "portfinder": "^1.0.26",
         "schema-utils": "^1.0.0",
-        "selfsigned": "^1.10.7",
+        "selfsigned": "^1.10.8",
         "semver": "^6.3.0",
         "serve-index": "^1.9.1",
-        "sockjs": "0.3.20",
-        "sockjs-client": "1.4.0",
+        "sockjs": "^0.3.21",
+        "sockjs-client": "^1.5.0",
         "spdy": "^4.0.2",
         "strip-ansi": "^3.0.1",
         "supports-color": "^6.1.0",
@@ -16133,16 +16097,16 @@
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         },
         "sockjs-client": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.4.0.tgz",
-          "integrity": "sha512-5zaLyO8/nri5cua0VtOrFXBPK1jbL4+1cebT/mmKA1E1ZXOvJrII75bPu0l0k843G/+iAbhEqzyKr0w/eCCj7g==",
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.5.0.tgz",
+          "integrity": "sha512-8Dt3BDi4FYNrCFGTL/HtwVzkARrENdwOUf1ZoW/9p3M8lZdFT35jVdrHza+qgxuG9H3/shR4cuX/X9umUrjP8Q==",
           "requires": {
-            "debug": "^3.2.5",
+            "debug": "^3.2.6",
             "eventsource": "^1.0.7",
-            "faye-websocket": "~0.11.1",
-            "inherits": "^2.0.3",
-            "json3": "^3.3.2",
-            "url-parse": "^1.4.3"
+            "faye-websocket": "^0.11.3",
+            "inherits": "^2.0.4",
+            "json3": "^3.3.3",
+            "url-parse": "^1.4.7"
           },
           "dependencies": {
             "debug": {
@@ -16546,9 +16510,9 @@
       }
     },
     "xstate": {
-      "version": "4.15.1",
-      "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.15.1.tgz",
-      "integrity": "sha512-8dD/GnTwxUuDr/cY42vi+Enu4mpbuUXWISYJ0a9BC+cIFvqufJsepyDLS6lLsznfUP0GS5Yx9m3IQWFhAoGt/A=="
+      "version": "4.15.3",
+      "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.15.3.tgz",
+      "integrity": "sha512-nf4zzLNs5W57stMZib9UG9PA5ywu89INsaXBMZf7iQxkYD9apbIOQcK8nu/iVZEDOVE+vR8GQnTaOg/8iDSK5Q=="
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "clsx": "^1.1.1",
     "gatsby": "^2.24.87",
+    "gatsby-plugin-jss": "^2.7.0",
     "gatsby-plugin-react-svg": "^3.0.0",
     "normalize.css": "^8.0.1",
     "react": "^16.12.0",

--- a/src/components/developers/developers.styles.js
+++ b/src/components/developers/developers.styles.js
@@ -26,10 +26,10 @@ const useDevelopersStyles = createUseStyles(theme => ({
     }
   },
   section: {
-    padding: `${theme.spacing(8)}px ${theme.spacing(2)}px ${theme.spacing(6)}px ${theme.spacing(2)}px`,
+    padding: `${theme.spacer * 8}px ${theme.spacer * 2}px ${theme.spacer * 6}px ${theme.spacer * 2}px`,
     flexDirection: 'column',
     [theme.breakpoints.sm]: {
-      padding: `${theme.spacing(12)}px ${theme.spacing(9)}px`,
+      padding: `${theme.spacer * 12}px ${theme.spacer * 9}px`,
       flexDirection: 'row'
     }
   },
@@ -40,12 +40,12 @@ const useDevelopersStyles = createUseStyles(theme => ({
     textAlign: 'center',
     [theme.breakpoints.sm]: {
       flexDirection: 'row',
-      paddingTop: theme.spacing(23),
+      paddingTop: theme.spacer * 23,
       textAlign: 'left'
     }
   },
   mainTitle: {
-    marginTop: theme.spacing(2),
+    marginTop: theme.spacer * 2,
     [theme.breakpoints.sm]: {
       marginTop: 'auto'
     }
@@ -58,17 +58,17 @@ const useDevelopersStyles = createUseStyles(theme => ({
     }
   },
   section2Title: {
-    marginBottom: theme.spacing(2),
+    marginBottom: theme.spacer * 2,
     [theme.breakpoints.sm]: {
       margin: 0
     }
   },
   section2Text: {
-    paddingTop: theme.spacing(2),
-    paddingBottom: theme.spacing(4),
+    paddingTop: theme.spacer * 2,
+    paddingBottom: theme.spacer * 4,
     [theme.breakpoints.sm]: {
-      paddingTop: theme.spacing(3),
-      paddingBottom: theme.spacing(10)
+      paddingTop: theme.spacer * 3,
+      paddingBottom: theme.spacer * 10
     }
   },
   section3: {
@@ -79,17 +79,17 @@ const useDevelopersStyles = createUseStyles(theme => ({
     }
   },
   section3Title: {
-    marginTop: theme.spacing(8),
-    marginBottom: theme.spacing(4),
+    marginTop: theme.spacer * 8,
+    marginBottom: theme.spacer * 4,
     [theme.breakpoints.sm]: {
-      marginTop: theme.spacing(16),
-      marginBottom: theme.spacing(8)
+      marginTop: theme.spacer * 16,
+      marginBottom: theme.spacer * 8
     }
   },
   section3SubTitle: {
-    marginBottom: theme.spacing(2),
+    marginBottom: theme.spacer * 2,
     [theme.breakpoints.sm]: {
-      marginBottom: theme.spacing(3)
+      marginBottom: theme.spacer * 3
     }
   },
   box: {
@@ -98,54 +98,54 @@ const useDevelopersStyles = createUseStyles(theme => ({
     fontSize: '23px',
     lineHeight: '35px',
     color: theme.palette.black,
-    maxHeight: theme.spacing(30),
-    padding: `${theme.spacing(8)}px ${theme.spacing(10)}px ${theme.spacing(8)}px ${theme.spacing(6.5)}px`,
+    maxHeight: theme.spacer * 30,
+    padding: `${theme.spacer * 8}px ${theme.spacer * 10}px ${theme.spacer * 8}px ${theme.spacer * 6.5}px`,
     textAlign: 'left',
-    marginBottom: theme.spacing(2),
+    marginBottom: theme.spacer * 2,
     [theme.breakpoints.sm]: {
-      marginBottom: theme.spacing(0),
-      marginRight: theme.spacing(4.5)
+      marginBottom: theme.spacer * 0,
+      marginRight: theme.spacer * 4.5
     }
   },
   highlightedText: {
-    fontSize: theme.spacing(4.25),
+    fontSize: theme.spacer * 4.25,
     fontWeight: theme.fontWeights.bold
   },
   section4: {
     '& $col3': {
       [theme.breakpoints.sm]: {
         margin: 0,
-        marginRight: theme.spacing(4)
+        marginRight: theme.spacer * 4
       }
     }
   },
   section4SubTitle: {
-    marginTop: theme.spacing(5),
-    marginBottom: theme.spacing(3),
+    marginTop: theme.spacer * 5,
+    marginBottom: theme.spacer * 3,
     '&:first-child': {
       marginTop: 0
     },
     [theme.breakpoints.sm]: {
-      marginTop: theme.spacing(0),
-      marginBottom: theme.spacing(0)
+      marginTop: theme.spacer * 0,
+      marginBottom: theme.spacer * 0
     }
   },
   circomText: {
-    marginBottom: theme.spacing(3),
+    marginBottom: theme.spacer * 3,
     [theme.breakpoints.sm]: {
-      marginTop: theme.spacing(4),
-      marginBottom: -theme.spacing(4)
+      marginTop: theme.spacer * 4,
+      marginBottom: -theme.spacer * 4
     }
   },
   divider: {
     width: '100%',
     height: '1px',
     background: theme.palette.primary.main,
-    marginTop: theme.spacing(0),
-    marginBottom: theme.spacing(5),
+    marginTop: theme.spacer * 0,
+    marginBottom: theme.spacer * 5,
     [theme.breakpoints.sm]: {
-      marginTop: theme.spacing(9),
-      marginBottom: theme.spacing(16)
+      marginTop: theme.spacer * 9,
+      marginBottom: theme.spacer * 16
     }
   },
   paragraphMargin: {
@@ -156,22 +156,22 @@ const useDevelopersStyles = createUseStyles(theme => ({
     backgroundPosition: 'bottom',
     backgroundSize: 'cover',
     borderRadius: 20,
-    padding: `${theme.spacing(6)}px ${theme.spacing(3.5)}px ${theme.spacing(4.5)}px`,
-    marginTop: theme.spacing(5),
+    padding: `${theme.spacer * 6}px ${theme.spacer * 3.5}px ${theme.spacer * 4.5}px`,
+    marginTop: theme.spacer * 5,
     [theme.breakpoints.sm]: {
       backgroundImage: 'url(./discord-link-background.svg)',
-      padding: theme.spacing(8),
+      padding: theme.spacer * 8,
       marginTop: 0
     }
   },
   discordText: {
     color: theme.palette.black,
     fontWeight: theme.fontWeights.bold,
-    fontSize: theme.spacing(3.5),
-    lineHeight: `${theme.spacing(4.5)}px`,
+    fontSize: theme.spacer * 3.5,
+    lineHeight: `${theme.spacer * 4.5}px`,
     [theme.breakpoints.sm]: {
-      fontSize: theme.spacing(5.25),
-      lineHeight: `${theme.spacing(7)}px`
+      fontSize: theme.spacer * 5.25,
+      lineHeight: `${theme.spacer * 7}px`
     }
   },
   onlyDesktop: {

--- a/src/components/footer/footer.styles.js
+++ b/src/components/footer/footer.styles.js
@@ -9,7 +9,7 @@ export const useFooterStyles = createUseStyles(theme => ({
   },
   content: {
     width: '100%',
-    padding: `${theme.spacing(11)}px ${theme.spacing(6)}px ${theme.spacing(6)}px`
+    padding: `${theme.spacer * 11}px ${theme.spacer * 6}px ${theme.spacer * 6}px`
   },
   topSection: {
     [theme.breakpoints.sm]: {
@@ -24,7 +24,7 @@ export const useFooterStyles = createUseStyles(theme => ({
     },
     display: 'flex',
     justifyContent: 'space-between',
-    marginTop: theme.spacing(12)
+    marginTop: theme.spacer * 12
   },
   col3: {
     display: 'flex',
@@ -37,24 +37,24 @@ export const useFooterStyles = createUseStyles(theme => ({
     [theme.breakpoints.sm]: {
       marginRight: '50%'
     },
-    marginBottom: theme.spacing(4),
+    marginBottom: theme.spacer * 4,
     '& :first-child, & :last-child': {
       color: theme.palette.white
     },
     '& :first-child': {
       fontWeight: theme.fontWeights.bold,
-      fontSize: theme.spacing(3),
-      lineHeight: `${theme.spacing(4) - 1}px`
+      fontSize: theme.spacer * 3,
+      lineHeight: `${theme.spacer * 4 - 1}px`
     },
     '& > *': {
-      lineHeight: `${theme.spacing(3)}px`,
-      marginBottom: theme.spacing(2)
+      lineHeight: `${theme.spacer * 3}px`,
+      marginBottom: theme.spacer * 2
     }
   },
   list: {
     listStyle: 'none',
     margin: 0,
-    marginBottom: theme.spacing(4),
+    marginBottom: theme.spacer * 4,
     width: '45%',
     '&:first-child': {
       marginRight: '10%'
@@ -67,7 +67,7 @@ export const useFooterStyles = createUseStyles(theme => ({
     }
   },
   listItem: {
-    lineHeight: `${theme.spacing(3)}px`,
+    lineHeight: `${theme.spacer * 3}px`,
     '&:hover': {
       color: theme.palette.white
     }
@@ -75,7 +75,7 @@ export const useFooterStyles = createUseStyles(theme => ({
   listItemHead: {
     color: theme.palette.white,
     fontWeight: theme.fontWeights.bold,
-    paddingBottom: theme.spacing(2)
+    paddingBottom: theme.spacer * 2
   },
   logoAndText: {
     flexDirection: 'column',
@@ -87,11 +87,11 @@ export const useFooterStyles = createUseStyles(theme => ({
     display: 'flex'
   },
   text: {
-    marginTop: theme.spacing(2.5),
+    marginTop: theme.spacer * 2.5,
     [theme.breakpoints.sm]: {
       marginTop: 0
     },
-    marginLeft: theme.spacing(0.5)
+    marginLeft: theme.spacer * 0.5
   },
   legalLink: {
     textDecoration: 'none',

--- a/src/components/header/header.component.jsx
+++ b/src/components/header/header.component.jsx
@@ -79,7 +79,7 @@ export const Header = ({ routes, onOpenMobileMenu }) => {
         </nav>
         <button className={classes.mobileMenu} onClick={onOpenMobileMenu}>
           <Logo />
-          <Menu size={theme.spacing(4)} />
+          <Menu size={theme.spacer * 4} />
         </button>
       </div>
     </header>

--- a/src/components/header/header.styles.js
+++ b/src/components/header/header.styles.js
@@ -7,7 +7,7 @@ export const useHeaderStyles = createUseStyles(theme => ({
   },
   content: {
     width: '100%',
-    padding: `${theme.spacing(3)}px ${theme.spacing(2)}px 0`
+    padding: `${theme.spacer * 3}px ${theme.spacer * 2}px 0`
   },
   nav: {
     display: 'none',
@@ -40,9 +40,9 @@ export const useHeaderStyles = createUseStyles(theme => ({
     width: '100%'
   },
   linkWrapper: {
-    paddingLeft: theme.spacing(2),
-    paddingRight: theme.spacing(2),
-    paddingTop: theme.spacing(1.5),
+    paddingLeft: theme.spacer * 2,
+    paddingRight: theme.spacer * 2,
+    paddingTop: theme.spacer * 1.5,
     textAlign: 'center',
     '&:first-child': {
       paddingLeft: 0,
@@ -58,17 +58,17 @@ export const useHeaderStyles = createUseStyles(theme => ({
     '&:last-child a': {
       border: `2px solid ${theme.palette.black}`,
       borderRadius: 15,
-      padding: `${theme.spacing(1.5)}px ${theme.spacing(3.5)}px`,
-      marginTop: theme.spacing(1.5)
+      padding: `${theme.spacer * 1.5}px ${theme.spacer * 3.5}px`,
+      marginTop: theme.spacer * 1.5
     },
     color: theme.palette.black,
     fontSize: '15px',
-    lineHeight: `${theme.spacing(2.5)}px`
+    lineHeight: `${theme.spacer * 2.5}px`
   },
   link: {
     display: 'flex',
     position: 'relative',
-    paddingBottom: theme.spacing(0.75),
+    paddingBottom: theme.spacer * 0.75,
     '&::after': {
       position: 'absolute',
       height: '2px',

--- a/src/components/home/home.styles.js
+++ b/src/components/home/home.styles.js
@@ -20,10 +20,10 @@ const useHomeStyles = createUseStyles(theme => ({
     }
   },
   section: {
-    padding: `${theme.spacing(8)}px ${theme.spacing(2)}px ${theme.spacing(6)}px ${theme.spacing(2)}px`,
+    padding: `${theme.spacer * 8}px ${theme.spacer * 2}px ${theme.spacer * 6}px ${theme.spacer * 2}px`,
     flexDirection: 'column',
     [theme.breakpoints.sm]: {
-      padding: `${theme.spacing(12)}px ${theme.spacing(9)}px`,
+      padding: `${theme.spacer * 12}px ${theme.spacer * 9}px`,
       flexDirection: 'row'
     }
   },
@@ -32,11 +32,11 @@ const useHomeStyles = createUseStyles(theme => ({
     backgroundPosition: 'bottom',
     backgroundSize: 'cover',
     display: 'flex',
-    paddingTop: theme.spacing(11),
+    paddingTop: theme.spacer * 11,
     textAlign: 'center',
-    height: theme.spacing(85),
+    height: theme.spacer * 85,
     [theme.breakpoints.sm]: {
-      paddingTop: theme.spacing(40),
+      paddingTop: theme.spacer * 40,
       textAlign: 'left',
       height: 'auto'
     },
@@ -46,7 +46,7 @@ const useHomeStyles = createUseStyles(theme => ({
   },
   section1Text: {
     color: theme.palette.black,
-    marginTop: theme.spacing(2)
+    marginTop: theme.spacer * 2
   },
   section1Image1: {
     position: 'absolute',
@@ -69,17 +69,17 @@ const useHomeStyles = createUseStyles(theme => ({
   section2Title: {
     textAlign: 'center',
     fontWeight: theme.fontWeights.medium,
-    fontSize: theme.spacing(2.5),
-    lineHeight: `${theme.spacing(4)}px`,
+    fontSize: theme.spacer * 2.5,
+    lineHeight: `${theme.spacer * 4}px`,
     [theme.breakpoints.sm]: {
-      fontSize: theme.spacing(4.25),
-      lineHeight: `${theme.spacing(5.75)}px`,
-      marginBottom: theme.spacing(13)
+      fontSize: theme.spacer * 4.25,
+      lineHeight: `${theme.spacer * 5.75}px`,
+      marginBottom: theme.spacer * 13
     }
   },
   section2Box: {
     textAlign: 'center',
-    marginTop: theme.spacing(5),
+    marginTop: theme.spacer * 5,
     [theme.breakpoints.sm]: {
       marginTop: 0
     }
@@ -99,13 +99,13 @@ const useHomeStyles = createUseStyles(theme => ({
   section2Text: {
     width: '245px',
     fontWeight: theme.fontWeights.medium,
-    fontSize: theme.spacing(2.5),
-    lineHeight: `${theme.spacing(4)}px`,
-    margin: `${theme.spacing(3)}px auto 0`,
+    fontSize: theme.spacer * 2.5,
+    lineHeight: `${theme.spacer * 4}px`,
+    margin: `${theme.spacer * 3}px auto 0`,
     [theme.breakpoints.sm]: {
-      fontSize: theme.spacing(3) - 1,
-      lineHeight: `${theme.spacing(4.5) - 1}px`,
-      margin: `${theme.spacing(6.25)}px auto 0`
+      fontSize: theme.spacer * 3 - 1,
+      lineHeight: `${theme.spacer * 4.5 - 1}px`,
+      margin: `${theme.spacer * 6.25}px auto 0`
     }
   },
   section3: {
@@ -114,20 +114,20 @@ const useHomeStyles = createUseStyles(theme => ({
   section3Text: {
     color: theme.palette.gray.light,
     lineHeight: '29px',
-    margin: `${theme.spacing(3)}px 0`
+    margin: `${theme.spacer * 3}px 0`
   },
   section4: {
     '& $divider': {
       [theme.breakpoints.sm]: {
-        margin: `${theme.spacing(7)}px 0 ${theme.spacing(8)}px auto`
+        margin: `${theme.spacer * 7}px 0 ${theme.spacer * 8}px auto`
       }
     }
   },
   section4Title: {
-    marginBottom: theme.spacing(2)
+    marginBottom: theme.spacer * 2
   },
   section4BoxWrapper: {
-    marginTop: theme.spacing(5),
+    marginTop: theme.spacer * 5,
     [theme.breakpoints.sm]: {
       marginTop: 'inherit'
     }
@@ -135,7 +135,7 @@ const useHomeStyles = createUseStyles(theme => ({
   section4Box: {
     marginTop: 0,
     [theme.breakpoints.sm]: {
-      marginRight: theme.spacing(4),
+      marginRight: theme.spacer * 4,
       '&:last-child': {
         marginRight: 0
       }
@@ -145,8 +145,8 @@ const useHomeStyles = createUseStyles(theme => ({
     backgroundColor: theme.palette.primary.light
   },
   section5Text: {
-    marginTop: theme.spacing(3),
-    marginBottom: theme.spacing(6)
+    marginTop: theme.spacer * 3,
+    marginBottom: theme.spacer * 6
   },
   barText: {
     color: theme.palette.black
@@ -156,42 +156,42 @@ const useHomeStyles = createUseStyles(theme => ({
   },
   barL1: {
     borderRadius: 15,
-    height: theme.spacing(2),
+    height: theme.spacer * 2,
     background: theme.palette.black,
-    marginTop: theme.spacing(1.5),
-    marginBottom: theme.spacing(3),
+    marginTop: theme.spacer * 1.5,
+    marginBottom: theme.spacer * 3,
     width: '100%'
   },
   barL2: {
     borderRadius: 15,
-    height: theme.spacing(2),
+    height: theme.spacer * 2,
     background: theme.palette.orange.main,
-    marginTop: theme.spacing(1.5),
+    marginTop: theme.spacer * 1.5,
     width: '10%'
   },
   section6: {
     '& $divider': {
       [theme.breakpoints.sm]: {
-        marginTop: theme.spacing(7),
-        marginBottom: theme.spacing(8)
+        marginTop: theme.spacer * 7,
+        marginBottom: theme.spacer * 8
       }
     }
   },
   section6Title: {
-    marginBottom: theme.spacing(2)
+    marginBottom: theme.spacer * 2
   },
   section6link: {
-    marginTop: theme.spacing(2.25),
+    marginTop: theme.spacer * 2.25,
     [theme.breakpoints.sm]: {
-      marginTop: theme.spacing(3.25)
+      marginTop: theme.spacer * 3.25
     }
   },
   section7: {
     backgroundColor: theme.palette.primary.light,
     '& $divider': {
       [theme.breakpoints.sm]: {
-        marginTop: theme.spacing(4),
-        marginBottom: theme.spacing(5)
+        marginTop: theme.spacer * 4,
+        marginBottom: theme.spacer * 5
       }
     }
   },
@@ -206,20 +206,20 @@ const useHomeStyles = createUseStyles(theme => ({
     background: theme.palette.primary.main,
     height: '1px',
     marginLeft: 'auto',
-    marginTop: theme.spacing(4),
-    marginBottom: theme.spacing(3),
+    marginTop: theme.spacer * 4,
+    marginBottom: theme.spacer * 3,
     width: '100%',
     [theme.breakpoints.sm]: {
-      marginTop: theme.spacing(4),
-      marginBottom: theme.spacing(5),
+      marginTop: theme.spacer * 4,
+      marginBottom: theme.spacer * 5,
       width: '50%'
     }
   },
   dividerFullWidth: {
     width: '100%',
     [theme.breakpoints.sm]: {
-      marginTop: theme.spacing(9),
-      marginBottom: theme.spacing(16)
+      marginTop: theme.spacer * 9,
+      marginBottom: theme.spacer * 16
     }
   },
   paragraphMargin: {
@@ -229,9 +229,9 @@ const useHomeStyles = createUseStyles(theme => ({
     display: 'flex',
     justifyContent: 'center',
     width: '100%',
-    marginTop: theme.spacing(7),
+    marginTop: theme.spacer * 7,
     [theme.breakpoints.sm]: {
-      marginTop: theme.spacing(12)
+      marginTop: theme.spacer * 12
     }
   },
   blogTitle: {
@@ -258,7 +258,7 @@ const useHomeStyles = createUseStyles(theme => ({
     }
   },
   blogLink: {
-    marginTop: theme.spacing(3.25)
+    marginTop: theme.spacer * 3.25
   },
   onlyDesktop: {
     display: 'none',

--- a/src/components/layout/layout.component.jsx
+++ b/src/components/layout/layout.component.jsx
@@ -1,6 +1,5 @@
 import React from 'react'
 
-import { theme } from '../../styles/theme'
 import { Header } from '../header/header.component'
 import { Main } from '../main/main.component'
 import { Footer } from '../footer/footer.component'
@@ -38,7 +37,7 @@ export const Layout = ({ children }) => {
   }
 
   return (
-    <div className={classes.layout} theme={theme}>
+    <div className={classes.layout}>
       <Header onOpenMobileMenu={handleMobileMenuToggle} routes={routes} />
       <MobileMenu
         isOpen={isMobileMenuOpen}

--- a/src/components/layout/layout.styles.js
+++ b/src/components/layout/layout.styles.js
@@ -1,97 +1,124 @@
 import { createUseStyles } from 'react-jss'
 
-export const useLayoutStyles = createUseStyles(theme => ({
-  '@font-face': [
-    {
-      fontFamily: 'Modern Era',
-      src: "url('/fonts/modern-era/ModernEra-Regular.woff2') format('woff2')",
-      fallbacks: [
-        { src: "url('/fonts/modern-era/ModernEra-Regular.woff') format('woff')" },
-        { src: "url('/fonts/modern-era/ModernEra-Regular.ttf') format('truetype')" }
-      ],
-      fontWeight: 400,
-      fontStyle: 'normal'
-    },
-    {
-      fontFamily: 'Modern Era',
-      src: "url('/fonts/modern-era/ModernEra-Medium.woff2') format('woff2')",
-      fallbacks: [
-        { src: "url('/fonts/modern-era/ModernEra-Medium.woff') format('woff')" },
-        { src: "url('/fonts/modern-era/ModernEra-Medium.ttf') format('truetype')" }
-      ],
-      fontWeight: 500,
-      fontStyle: 'normal'
-    },
-    {
-      fontFamily: 'Modern Era',
-      src: "url('/fonts/modern-era/ModernEra-Bold.woff2') format('woff2')",
-      fallbacks: [
-        { src: "url('/fonts/modern-era/ModernEra-Bold.woff') format('woff')" },
-        { src: "url('/fonts/modern-era/ModernEra-Bold.ttf') format('truetype')" }
-      ],
-      fontWeight: 700,
-      fontStyle: 'normal'
-    },
-    {
-      fontFamily: 'Modern Era',
-      src: "url('/fonts/modern-era/ModernEra-ExtraBold.woff2') format('woff2')",
-      fallbacks: [
-        { src: "url('/fonts/modern-era/ModernEra-ExtraBold.woff') format('woff')" },
-        { src: "url('/fonts/modern-era/ModernEra-ExtraBold.ttf') format('truetype')" }
-      ],
-      fontWeight: 800,
-      fontStyle: 'normal'
-    }
-  ],
-  '@global': {
-    '*': {
-      boxSizing: 'border-box'
-    },
-    html: {
-      minHeight: '100vh',
-      height: '100%',
-      margin: 0
-    },
-    body: {
-      fontFamily: 'Modern Era',
-      fontWeight: 400,
-      minHeight: '100vh',
-      margin: 0,
-      fontSize: theme.spacing(2),
-      lineHeight: `${theme.spacing(3)}px`,
-      color: theme.palette.gray.light,
-      [theme.breakpoints.sm]: {
-        fontSize: (theme.spacing(2) + 1),
-        lineHeight: '29px'
+export const useLayoutStyles = createUseStyles((theme) => {
+  console.log(theme)
+  return {
+    '@font-face': [
+      {
+        fontFamily: 'Modern Era',
+        src: "url('/fonts/modern-era/ModernEra-Regular.woff2') format('woff2')",
+        fallbacks: [
+          {
+            src:
+              "url('/fonts/modern-era/ModernEra-Regular.woff') format('woff')"
+          },
+          {
+            src:
+              "url('/fonts/modern-era/ModernEra-Regular.ttf') format('truetype')"
+          }
+        ],
+        fontWeight: 400,
+        fontStyle: 'normal'
+      },
+      {
+        fontFamily: 'Modern Era',
+        src: "url('/fonts/modern-era/ModernEra-Medium.woff2') format('woff2')",
+        fallbacks: [
+          {
+            src:
+              "url('/fonts/modern-era/ModernEra-Medium.woff') format('woff')"
+          },
+          {
+            src:
+              "url('/fonts/modern-era/ModernEra-Medium.ttf') format('truetype')"
+          }
+        ],
+        fontWeight: 500,
+        fontStyle: 'normal'
+      },
+      {
+        fontFamily: 'Modern Era',
+        src: "url('/fonts/modern-era/ModernEra-Bold.woff2') format('woff2')",
+        fallbacks: [
+          {
+            src: "url('/fonts/modern-era/ModernEra-Bold.woff') format('woff')"
+          },
+          {
+            src:
+              "url('/fonts/modern-era/ModernEra-Bold.ttf') format('truetype')"
+          }
+        ],
+        fontWeight: 700,
+        fontStyle: 'normal'
+      },
+      {
+        fontFamily: 'Modern Era',
+        src:
+          "url('/fonts/modern-era/ModernEra-ExtraBold.woff2') format('woff2')",
+        fallbacks: [
+          {
+            src:
+              "url('/fonts/modern-era/ModernEra-ExtraBold.woff') format('woff')"
+          },
+          {
+            src:
+              "url('/fonts/modern-era/ModernEra-ExtraBold.ttf') format('truetype')"
+          }
+        ],
+        fontWeight: 800,
+        fontStyle: 'normal'
+      }
+    ],
+    '@global': {
+      '*': {
+        boxSizing: 'border-box'
+      },
+      html: {
+        minHeight: '100vh',
+        height: '100%',
+        margin: 0
+      },
+      body: {
+        fontFamily: 'Modern Era',
+        fontWeight: 400,
+        minHeight: '100vh',
+        margin: 0,
+        fontSize: theme.spacer * 2,
+        lineHeight: `${theme.spacer * 3}px`,
+        color: theme.palette.gray.light,
+        [theme.breakpoints.sm]: {
+          fontSize: theme.spacer * 2 + 1,
+          lineHeight: '29px'
+        }
+      },
+      a: {
+        textDecoration: 'none',
+        color: 'inherit'
+      },
+      p: {
+        margin: 0
+      },
+      'h1, h2, h3, h4': {
+        margin: 0,
+        marginBlockStart: 0,
+        marginBlockEnd: 0
+      },
+      ul: {
+        marginBlock: 0,
+        paddingInline: 0
       }
     },
-    a: {
-      textDecoration: 'none',
-      color: 'inherit'
-    },
-    p: {
-      margin: 0
-    },
-    'h1, h2, h3, h4': {
-      margin: 0,
-      marginBlockStart: 0,
-      marginBlockEnd: 0
-    },
-    ul: {
-      marginBlock: 0,
-      paddingInline: 0
+    layout: {
+      width: '100%',
+      display: 'flex',
+      flexDirection: 'column',
+      [theme.breakpoints.lg]: {
+        maxWidth: '1200px'
+      },
+      [theme.breakpoints.xl]: {
+        maxWidth: '1440px'
+      },
+      maxWidth: '100%'
     }
-  },
-  layout: {
-    width: '100%',
-    display: 'flex',
-    flexDirection: 'column',
-    [theme.breakpoints.lg]: {
-      maxWidth: '1200px'
-    },
-    [theme.breakpoints.xl]: {
-      maxWidth: '1440px'
-    },
-    maxWidth: '100%'
   }
-}))
+})

--- a/src/components/layout/layout.styles.js
+++ b/src/components/layout/layout.styles.js
@@ -109,6 +109,9 @@ export const useLayoutStyles = createUseStyles((theme) => ({
     [theme.breakpoints.lg]: {
       maxWidth: '1200px'
     },
+    [theme.breakpoints.xl]: {
+      maxWidth: '100%'
+    },
     maxWidth: '100%'
   }
 }))

--- a/src/components/layout/layout.styles.js
+++ b/src/components/layout/layout.styles.js
@@ -115,9 +115,6 @@ export const useLayoutStyles = createUseStyles((theme) => {
       [theme.breakpoints.lg]: {
         maxWidth: '1200px'
       },
-      [theme.breakpoints.xl]: {
-        maxWidth: '1440px'
-      },
       maxWidth: '100%'
     }
   }

--- a/src/components/layout/layout.styles.js
+++ b/src/components/layout/layout.styles.js
@@ -1,121 +1,114 @@
 import { createUseStyles } from 'react-jss'
 
-export const useLayoutStyles = createUseStyles((theme) => {
-  console.log(theme)
-  return {
-    '@font-face': [
-      {
-        fontFamily: 'Modern Era',
-        src: "url('/fonts/modern-era/ModernEra-Regular.woff2') format('woff2')",
-        fallbacks: [
-          {
-            src:
-              "url('/fonts/modern-era/ModernEra-Regular.woff') format('woff')"
-          },
-          {
-            src:
-              "url('/fonts/modern-era/ModernEra-Regular.ttf') format('truetype')"
-          }
-        ],
-        fontWeight: 400,
-        fontStyle: 'normal'
-      },
-      {
-        fontFamily: 'Modern Era',
-        src: "url('/fonts/modern-era/ModernEra-Medium.woff2') format('woff2')",
-        fallbacks: [
-          {
-            src:
-              "url('/fonts/modern-era/ModernEra-Medium.woff') format('woff')"
-          },
-          {
-            src:
-              "url('/fonts/modern-era/ModernEra-Medium.ttf') format('truetype')"
-          }
-        ],
-        fontWeight: 500,
-        fontStyle: 'normal'
-      },
-      {
-        fontFamily: 'Modern Era',
-        src: "url('/fonts/modern-era/ModernEra-Bold.woff2') format('woff2')",
-        fallbacks: [
-          {
-            src: "url('/fonts/modern-era/ModernEra-Bold.woff') format('woff')"
-          },
-          {
-            src:
-              "url('/fonts/modern-era/ModernEra-Bold.ttf') format('truetype')"
-          }
-        ],
-        fontWeight: 700,
-        fontStyle: 'normal'
-      },
-      {
-        fontFamily: 'Modern Era',
-        src:
-          "url('/fonts/modern-era/ModernEra-ExtraBold.woff2') format('woff2')",
-        fallbacks: [
-          {
-            src:
-              "url('/fonts/modern-era/ModernEra-ExtraBold.woff') format('woff')"
-          },
-          {
-            src:
-              "url('/fonts/modern-era/ModernEra-ExtraBold.ttf') format('truetype')"
-          }
-        ],
-        fontWeight: 800,
-        fontStyle: 'normal'
-      }
-    ],
-    '@global': {
-      '*': {
-        boxSizing: 'border-box'
-      },
-      html: {
-        minHeight: '100vh',
-        height: '100%',
-        margin: 0
-      },
-      body: {
-        fontFamily: 'Modern Era',
-        fontWeight: 400,
-        minHeight: '100vh',
-        margin: 0,
-        fontSize: theme.spacer * 2,
-        lineHeight: `${theme.spacer * 3}px`,
-        color: theme.palette.gray.light,
-        [theme.breakpoints.sm]: {
-          fontSize: theme.spacer * 2 + 1,
-          lineHeight: '29px'
+export const useLayoutStyles = createUseStyles((theme) => ({
+  '@font-face': [
+    {
+      fontFamily: 'Modern Era',
+      src: "url('/fonts/modern-era/ModernEra-Regular.woff2') format('woff2')",
+      fallbacks: [
+        {
+          src: "url('/fonts/modern-era/ModernEra-Regular.woff') format('woff')"
+        },
+        {
+          src:
+            "url('/fonts/modern-era/ModernEra-Regular.ttf') format('truetype')"
         }
-      },
-      a: {
-        textDecoration: 'none',
-        color: 'inherit'
-      },
-      p: {
-        margin: 0
-      },
-      'h1, h2, h3, h4': {
-        margin: 0,
-        marginBlockStart: 0,
-        marginBlockEnd: 0
-      },
-      ul: {
-        marginBlock: 0,
-        paddingInline: 0
+      ],
+      fontWeight: 400,
+      fontStyle: 'normal'
+    },
+    {
+      fontFamily: 'Modern Era',
+      src: "url('/fonts/modern-era/ModernEra-Medium.woff2') format('woff2')",
+      fallbacks: [
+        {
+          src: "url('/fonts/modern-era/ModernEra-Medium.woff') format('woff')"
+        },
+        {
+          src:
+            "url('/fonts/modern-era/ModernEra-Medium.ttf') format('truetype')"
+        }
+      ],
+      fontWeight: 500,
+      fontStyle: 'normal'
+    },
+    {
+      fontFamily: 'Modern Era',
+      src: "url('/fonts/modern-era/ModernEra-Bold.woff2') format('woff2')",
+      fallbacks: [
+        {
+          src: "url('/fonts/modern-era/ModernEra-Bold.woff') format('woff')"
+        },
+        {
+          src: "url('/fonts/modern-era/ModernEra-Bold.ttf') format('truetype')"
+        }
+      ],
+      fontWeight: 700,
+      fontStyle: 'normal'
+    },
+    {
+      fontFamily: 'Modern Era',
+      src: "url('/fonts/modern-era/ModernEra-ExtraBold.woff2') format('woff2')",
+      fallbacks: [
+        {
+          src:
+            "url('/fonts/modern-era/ModernEra-ExtraBold.woff') format('woff')"
+        },
+        {
+          src:
+            "url('/fonts/modern-era/ModernEra-ExtraBold.ttf') format('truetype')"
+        }
+      ],
+      fontWeight: 800,
+      fontStyle: 'normal'
+    }
+  ],
+  '@global': {
+    '*': {
+      boxSizing: 'border-box'
+    },
+    html: {
+      minHeight: '100vh',
+      height: '100%',
+      margin: 0
+    },
+    body: {
+      fontFamily: 'Modern Era',
+      fontWeight: 400,
+      minHeight: '100vh',
+      margin: 0,
+      fontSize: theme.spacer * 2,
+      lineHeight: `${theme.spacer * 3}px`,
+      color: theme.palette.gray.light,
+      [theme.breakpoints.sm]: {
+        fontSize: theme.spacer * 2 + 1,
+        lineHeight: '29px'
       }
     },
-    layout: {
-      width: '100%',
-      display: 'flex',
-      flexDirection: 'column',
-      [theme.breakpoints.lg]: {
-        maxWidth: '1200px'
-      },
-      maxWidth: '100%'
+    a: {
+      textDecoration: 'none',
+      color: 'inherit'
+    },
+    p: {
+      margin: 0
+    },
+    'h1, h2, h3, h4': {
+      margin: 0,
+      marginBlockStart: 0,
+      marginBlockEnd: 0
+    },
+    ul: {
+      marginBlock: 0,
+      paddingInline: 0
     }
+  },
+  layout: {
+    width: '100%',
+    display: 'flex',
+    flexDirection: 'column',
+    [theme.breakpoints.lg]: {
+      maxWidth: '1200px'
+    },
+    maxWidth: '100%'
   }
-})
+}))

--- a/src/components/layout/layout.styles.js
+++ b/src/components/layout/layout.styles.js
@@ -1,124 +1,117 @@
 import { createUseStyles } from 'react-jss'
 
-export const useLayoutStyles = createUseStyles((theme) => {
-  console.log(theme)
-  return {
-    '@font-face': [
-      {
-        fontFamily: 'Modern Era',
-        src: "url('/fonts/modern-era/ModernEra-Regular.woff2') format('woff2')",
-        fallbacks: [
-          {
-            src:
-              "url('/fonts/modern-era/ModernEra-Regular.woff') format('woff')"
-          },
-          {
-            src:
-              "url('/fonts/modern-era/ModernEra-Regular.ttf') format('truetype')"
-          }
-        ],
-        fontWeight: 400,
-        fontStyle: 'normal'
-      },
-      {
-        fontFamily: 'Modern Era',
-        src: "url('/fonts/modern-era/ModernEra-Medium.woff2') format('woff2')",
-        fallbacks: [
-          {
-            src:
-              "url('/fonts/modern-era/ModernEra-Medium.woff') format('woff')"
-          },
-          {
-            src:
-              "url('/fonts/modern-era/ModernEra-Medium.ttf') format('truetype')"
-          }
-        ],
-        fontWeight: 500,
-        fontStyle: 'normal'
-      },
-      {
-        fontFamily: 'Modern Era',
-        src: "url('/fonts/modern-era/ModernEra-Bold.woff2') format('woff2')",
-        fallbacks: [
-          {
-            src: "url('/fonts/modern-era/ModernEra-Bold.woff') format('woff')"
-          },
-          {
-            src:
-              "url('/fonts/modern-era/ModernEra-Bold.ttf') format('truetype')"
-          }
-        ],
-        fontWeight: 700,
-        fontStyle: 'normal'
-      },
-      {
-        fontFamily: 'Modern Era',
-        src:
-          "url('/fonts/modern-era/ModernEra-ExtraBold.woff2') format('woff2')",
-        fallbacks: [
-          {
-            src:
-              "url('/fonts/modern-era/ModernEra-ExtraBold.woff') format('woff')"
-          },
-          {
-            src:
-              "url('/fonts/modern-era/ModernEra-ExtraBold.ttf') format('truetype')"
-          }
-        ],
-        fontWeight: 800,
-        fontStyle: 'normal'
-      }
-    ],
-    '@global': {
-      '*': {
-        boxSizing: 'border-box'
-      },
-      html: {
-        minHeight: '100vh',
-        height: '100%',
-        margin: 0
-      },
-      body: {
-        fontFamily: 'Modern Era',
-        fontWeight: 400,
-        minHeight: '100vh',
-        margin: 0,
-        fontSize: theme.spacer * 2,
-        lineHeight: `${theme.spacer * 3}px`,
-        color: theme.palette.gray.light,
-        [theme.breakpoints.sm]: {
-          fontSize: theme.spacer * 2 + 1,
-          lineHeight: '29px'
+export const useLayoutStyles = createUseStyles((theme) => ({
+  '@font-face': [
+    {
+      fontFamily: 'Modern Era',
+      src: "url('/fonts/modern-era/ModernEra-Regular.woff2') format('woff2')",
+      fallbacks: [
+        {
+          src: "url('/fonts/modern-era/ModernEra-Regular.woff') format('woff')"
+        },
+        {
+          src:
+            "url('/fonts/modern-era/ModernEra-Regular.ttf') format('truetype')"
         }
-      },
-      a: {
-        textDecoration: 'none',
-        color: 'inherit'
-      },
-      p: {
-        margin: 0
-      },
-      'h1, h2, h3, h4': {
-        margin: 0,
-        marginBlockStart: 0,
-        marginBlockEnd: 0
-      },
-      ul: {
-        marginBlock: 0,
-        paddingInline: 0
+      ],
+      fontWeight: 400,
+      fontStyle: 'normal'
+    },
+    {
+      fontFamily: 'Modern Era',
+      src: "url('/fonts/modern-era/ModernEra-Medium.woff2') format('woff2')",
+      fallbacks: [
+        {
+          src: "url('/fonts/modern-era/ModernEra-Medium.woff') format('woff')"
+        },
+        {
+          src:
+            "url('/fonts/modern-era/ModernEra-Medium.ttf') format('truetype')"
+        }
+      ],
+      fontWeight: 500,
+      fontStyle: 'normal'
+    },
+    {
+      fontFamily: 'Modern Era',
+      src: "url('/fonts/modern-era/ModernEra-Bold.woff2') format('woff2')",
+      fallbacks: [
+        {
+          src: "url('/fonts/modern-era/ModernEra-Bold.woff') format('woff')"
+        },
+        {
+          src: "url('/fonts/modern-era/ModernEra-Bold.ttf') format('truetype')"
+        }
+      ],
+      fontWeight: 700,
+      fontStyle: 'normal'
+    },
+    {
+      fontFamily: 'Modern Era',
+      src: "url('/fonts/modern-era/ModernEra-ExtraBold.woff2') format('woff2')",
+      fallbacks: [
+        {
+          src:
+            "url('/fonts/modern-era/ModernEra-ExtraBold.woff') format('woff')"
+        },
+        {
+          src:
+            "url('/fonts/modern-era/ModernEra-ExtraBold.ttf') format('truetype')"
+        }
+      ],
+      fontWeight: 800,
+      fontStyle: 'normal'
+    }
+  ],
+  '@global': {
+    '*': {
+      boxSizing: 'border-box'
+    },
+    html: {
+      minHeight: '100vh',
+      height: '100%',
+      margin: 0
+    },
+    body: {
+      fontFamily: 'Modern Era',
+      fontWeight: 400,
+      minHeight: '100vh',
+      margin: 0,
+      fontSize: theme.spacer * 2,
+      lineHeight: `${theme.spacer * 3}px`,
+      color: theme.palette.gray.light,
+      [theme.breakpoints.sm]: {
+        fontSize: theme.spacer * 2 + 1,
+        lineHeight: '29px'
       }
     },
-    layout: {
-      width: '100%',
-      display: 'flex',
-      flexDirection: 'column',
-      [theme.breakpoints.lg]: {
-        maxWidth: '1200px'
-      },
-      [theme.breakpoints.xl]: {
-        maxWidth: '1440px'
-      },
-      maxWidth: '100%'
+    a: {
+      textDecoration: 'none',
+      color: 'inherit'
+    },
+    p: {
+      margin: 0
+    },
+    'h1, h2, h3, h4': {
+      margin: 0,
+      marginBlockStart: 0,
+      marginBlockEnd: 0
+    },
+    ul: {
+      marginBlock: 0,
+      paddingInline: 0
     }
+  },
+  layout: {
+    width: '100%',
+    display: 'flex',
+    flexDirection: 'column',
+    [theme.breakpoints.lg]: {
+      maxWidth: '1200px'
+    },
+    [theme.breakpoints.xl]: {
+      maxWidth: '1440px'
+    },
+    maxWidth: '100%'
   }
-})
+}))

--- a/src/components/layout/layout.styles.js
+++ b/src/components/layout/layout.styles.js
@@ -1,114 +1,121 @@
 import { createUseStyles } from 'react-jss'
 
-export const useLayoutStyles = createUseStyles((theme) => ({
-  '@font-face': [
-    {
-      fontFamily: 'Modern Era',
-      src: "url('/fonts/modern-era/ModernEra-Regular.woff2') format('woff2')",
-      fallbacks: [
-        {
-          src: "url('/fonts/modern-era/ModernEra-Regular.woff') format('woff')"
-        },
-        {
-          src:
-            "url('/fonts/modern-era/ModernEra-Regular.ttf') format('truetype')"
+export const useLayoutStyles = createUseStyles((theme) => {
+  console.log(theme)
+  return {
+    '@font-face': [
+      {
+        fontFamily: 'Modern Era',
+        src: "url('/fonts/modern-era/ModernEra-Regular.woff2') format('woff2')",
+        fallbacks: [
+          {
+            src:
+              "url('/fonts/modern-era/ModernEra-Regular.woff') format('woff')"
+          },
+          {
+            src:
+              "url('/fonts/modern-era/ModernEra-Regular.ttf') format('truetype')"
+          }
+        ],
+        fontWeight: 400,
+        fontStyle: 'normal'
+      },
+      {
+        fontFamily: 'Modern Era',
+        src: "url('/fonts/modern-era/ModernEra-Medium.woff2') format('woff2')",
+        fallbacks: [
+          {
+            src:
+              "url('/fonts/modern-era/ModernEra-Medium.woff') format('woff')"
+          },
+          {
+            src:
+              "url('/fonts/modern-era/ModernEra-Medium.ttf') format('truetype')"
+          }
+        ],
+        fontWeight: 500,
+        fontStyle: 'normal'
+      },
+      {
+        fontFamily: 'Modern Era',
+        src: "url('/fonts/modern-era/ModernEra-Bold.woff2') format('woff2')",
+        fallbacks: [
+          {
+            src: "url('/fonts/modern-era/ModernEra-Bold.woff') format('woff')"
+          },
+          {
+            src:
+              "url('/fonts/modern-era/ModernEra-Bold.ttf') format('truetype')"
+          }
+        ],
+        fontWeight: 700,
+        fontStyle: 'normal'
+      },
+      {
+        fontFamily: 'Modern Era',
+        src:
+          "url('/fonts/modern-era/ModernEra-ExtraBold.woff2') format('woff2')",
+        fallbacks: [
+          {
+            src:
+              "url('/fonts/modern-era/ModernEra-ExtraBold.woff') format('woff')"
+          },
+          {
+            src:
+              "url('/fonts/modern-era/ModernEra-ExtraBold.ttf') format('truetype')"
+          }
+        ],
+        fontWeight: 800,
+        fontStyle: 'normal'
+      }
+    ],
+    '@global': {
+      '*': {
+        boxSizing: 'border-box'
+      },
+      html: {
+        minHeight: '100vh',
+        height: '100%',
+        margin: 0
+      },
+      body: {
+        fontFamily: 'Modern Era',
+        fontWeight: 400,
+        minHeight: '100vh',
+        margin: 0,
+        fontSize: theme.spacer * 2,
+        lineHeight: `${theme.spacer * 3}px`,
+        color: theme.palette.gray.light,
+        [theme.breakpoints.sm]: {
+          fontSize: theme.spacer * 2 + 1,
+          lineHeight: '29px'
         }
-      ],
-      fontWeight: 400,
-      fontStyle: 'normal'
-    },
-    {
-      fontFamily: 'Modern Era',
-      src: "url('/fonts/modern-era/ModernEra-Medium.woff2') format('woff2')",
-      fallbacks: [
-        {
-          src: "url('/fonts/modern-era/ModernEra-Medium.woff') format('woff')"
-        },
-        {
-          src:
-            "url('/fonts/modern-era/ModernEra-Medium.ttf') format('truetype')"
-        }
-      ],
-      fontWeight: 500,
-      fontStyle: 'normal'
-    },
-    {
-      fontFamily: 'Modern Era',
-      src: "url('/fonts/modern-era/ModernEra-Bold.woff2') format('woff2')",
-      fallbacks: [
-        {
-          src: "url('/fonts/modern-era/ModernEra-Bold.woff') format('woff')"
-        },
-        {
-          src: "url('/fonts/modern-era/ModernEra-Bold.ttf') format('truetype')"
-        }
-      ],
-      fontWeight: 700,
-      fontStyle: 'normal'
-    },
-    {
-      fontFamily: 'Modern Era',
-      src: "url('/fonts/modern-era/ModernEra-ExtraBold.woff2') format('woff2')",
-      fallbacks: [
-        {
-          src:
-            "url('/fonts/modern-era/ModernEra-ExtraBold.woff') format('woff')"
-        },
-        {
-          src:
-            "url('/fonts/modern-era/ModernEra-ExtraBold.ttf') format('truetype')"
-        }
-      ],
-      fontWeight: 800,
-      fontStyle: 'normal'
-    }
-  ],
-  '@global': {
-    '*': {
-      boxSizing: 'border-box'
-    },
-    html: {
-      minHeight: '100vh',
-      height: '100%',
-      margin: 0
-    },
-    body: {
-      fontFamily: 'Modern Era',
-      fontWeight: 400,
-      minHeight: '100vh',
-      margin: 0,
-      fontSize: theme.spacer * 2,
-      lineHeight: `${theme.spacer * 3}px`,
-      color: theme.palette.gray.light,
-      [theme.breakpoints.sm]: {
-        fontSize: theme.spacer * 2 + 1,
-        lineHeight: '29px'
+      },
+      a: {
+        textDecoration: 'none',
+        color: 'inherit'
+      },
+      p: {
+        margin: 0
+      },
+      'h1, h2, h3, h4': {
+        margin: 0,
+        marginBlockStart: 0,
+        marginBlockEnd: 0
+      },
+      ul: {
+        marginBlock: 0,
+        paddingInline: 0
       }
     },
-    a: {
-      textDecoration: 'none',
-      color: 'inherit'
-    },
-    p: {
-      margin: 0
-    },
-    'h1, h2, h3, h4': {
-      margin: 0,
-      marginBlockStart: 0,
-      marginBlockEnd: 0
-    },
-    ul: {
-      marginBlock: 0,
-      paddingInline: 0
+    layout: {
+      width: '100%',
+      display: 'flex',
+      flexDirection: 'column',
+      [theme.breakpoints.lg]: {
+        maxWidth: '1200px'
+      },
+      maxWidth: '100%'
     }
-  },
-  layout: {
-    width: '100%',
-    display: 'flex',
-    flexDirection: 'column',
-    [theme.breakpoints.lg]: {
-      maxWidth: '1200px'
-    },
-    maxWidth: '100%'
   }
-}))
+})

--- a/src/components/legal-disclaimer/legal-disclaimer.styles.js
+++ b/src/components/legal-disclaimer/legal-disclaimer.styles.js
@@ -2,19 +2,19 @@ import { createUseStyles } from 'react-jss'
 
 const useLegalDisclaimerStyles = createUseStyles(theme => ({
   section: {
-    padding: `0 ${theme.spacing(4) - 3}px ${theme.spacing(6)}px ${theme.spacing(2)}px`,
+    padding: `0 ${theme.spacer * 4 - 3}px ${theme.spacer * 6}px ${theme.spacer * 2}px`,
     [theme.breakpoints.sm]: {
-      padding: `${theme.spacing(12)}px ${theme.spacing(9)}px`
+      padding: `${theme.spacer * 12}px ${theme.spacer * 9}px`
     },
     background: theme.palette.primary.light,
     color: theme.palette.gray.light
   },
   title: {
-    paddingTop: theme.spacing(10),
-    marginBottom: theme.spacing(5)
+    paddingTop: theme.spacer * 10,
+    marginBottom: theme.spacer * 5
   },
   paragraphMargin: {
-    marginBottom: theme.spacing(2)
+    marginBottom: theme.spacer * 2
   }
 }))
 

--- a/src/components/media-inquiries/media-inquiries.styles.js
+++ b/src/components/media-inquiries/media-inquiries.styles.js
@@ -2,28 +2,28 @@ import { createUseStyles } from 'react-jss'
 
 const useMediaInquiriesStyles = createUseStyles(theme => ({
   section: {
-    paddingRight: theme.spacing(4) - 3,
-    paddingLeft: theme.spacing(2),
+    paddingRight: theme.spacer * 4 - 3,
+    paddingLeft: theme.spacer * 2,
     [theme.breakpoints.sm]: {
       paddingRight: 0,
       paddingLeft: 0
     },
     background: theme.palette.primary.light,
     color: theme.palette.gray.light,
-    paddingTop: theme.spacing(34),
-    paddingBottom: theme.spacing(36),
+    paddingTop: theme.spacer * 34,
+    paddingBottom: theme.spacer * 36,
     textAlign: 'center'
   },
   contentWrapper: {
-    maxWidth: theme.spacing(75),
+    maxWidth: theme.spacer * 75,
     margin: 'auto'
   },
   title: {
-    marginBottom: theme.spacing(3)
+    marginBottom: theme.spacer * 3
   },
   email: {
     color: theme.palette.orange.main,
-    padding: `0 ${theme.spacing(1)}px`
+    padding: `0 ${theme.spacer * 1}px`
   },
   buttonWrapper: {
     display: 'flex',

--- a/src/components/mobile-menu/mobile-menu.component.jsx
+++ b/src/components/mobile-menu/mobile-menu.component.jsx
@@ -46,7 +46,7 @@ export const MobileMenu = ({ routes, isOpen, onClose }) => {
           <div className={classes.sidebarHeader}>
             <Logo />
             <button className={classes.closeButton} onClick={onClose}>
-              <X size={theme.spacing(4)} />
+              <X size={theme.spacer * 4} />
             </button>
           </div>
           <ul className={classes.linkList}>

--- a/src/components/mobile-menu/mobile-menu.styles.js
+++ b/src/components/mobile-menu/mobile-menu.styles.js
@@ -20,16 +20,16 @@ export const useMobileMenuStyles = createUseStyles(theme => ({
     right: 0,
     left: 0,
     background: theme.palette.white,
-    padding: `0 ${theme.spacing(2)}px`,
+    padding: `0 ${theme.spacer * 2}px`,
     display: 'flex',
     flexDirection: 'column',
     '&:focus': {
       outline: 'none'
     },
     [theme.breakpoints.sm]: {
-      width: theme.spacing(50),
+      width: theme.spacer * 50,
       right: 'auto',
-      padding: `0 ${theme.spacing(8)}px`
+      padding: `0 ${theme.spacer * 8}px`
     },
     [theme.breakpoints.md]: {
       display: 'none'
@@ -39,7 +39,7 @@ export const useMobileMenuStyles = createUseStyles(theme => ({
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'space-between',
-    paddingTop: theme.spacing(3)
+    paddingTop: theme.spacer * 3
   },
   title: {
     margin: 0
@@ -60,10 +60,10 @@ export const useMobileMenuStyles = createUseStyles(theme => ({
     flexDirection: 'column',
     listStyle: 'none',
     margin: 0,
-    marginTop: theme.spacing(2),
+    marginTop: theme.spacer * 2,
     paddingLeft: 0,
     [theme.breakpoints.sm]: {
-      marginTop: theme.spacing(4)
+      marginTop: theme.spacer * 4
     }
   },
   linkWrapper: {
@@ -72,10 +72,10 @@ export const useMobileMenuStyles = createUseStyles(theme => ({
   link: {
     textDecoration: 'none',
     width: '100%',
-    padding: theme.spacing(2),
+    padding: theme.spacer * 2,
     color: theme.palette.black,
-    fontSize: theme.spacing(3.5),
-    lineHeight: `${theme.spacing(4.5)}px`
+    fontSize: theme.spacer * 3.5,
+    lineHeight: `${theme.spacer * 4.5}px`
   },
   activeLink: {
     color: theme.palette.orange.main

--- a/src/components/payments-network/payments-network.styles.js
+++ b/src/components/payments-network/payments-network.styles.js
@@ -26,10 +26,10 @@ const usePaymentsNetworkStyles = createUseStyles(theme => ({
     }
   },
   section: {
-    padding: `${theme.spacing(8)}px ${theme.spacing(2)}px ${theme.spacing(6)}px ${theme.spacing(2)}px`,
+    padding: `${theme.spacer * 8}px ${theme.spacer * 2}px ${theme.spacer * 6}px ${theme.spacer * 2}px`,
     flexDirection: 'column',
     [theme.breakpoints.sm]: {
-      padding: `${theme.spacing(17)}px ${theme.spacing(9)}px ${theme.spacing(17)}px`,
+      padding: `${theme.spacer * 17}px ${theme.spacer * 9}px ${theme.spacer * 17}px`,
       flexDirection: 'row'
     }
   },
@@ -37,18 +37,18 @@ const usePaymentsNetworkStyles = createUseStyles(theme => ({
     backgroundColor: theme.palette.primary.light,
     display: 'flex',
     flexDirection: 'column-reverse',
-    paddingTop: theme.spacing(8),
-    paddingBottom: theme.spacing(9.5),
+    paddingTop: theme.spacer * 8,
+    paddingBottom: theme.spacer * 9.5,
     textAlign: 'center',
     [theme.breakpoints.sm]: {
       flexDirection: 'row',
-      paddingTop: theme.spacing(19),
-      paddingBottom: theme.spacing(26),
+      paddingTop: theme.spacer * 19,
+      paddingBottom: theme.spacer * 26,
       textAlign: 'left'
     }
   },
   mainTitle: {
-    marginTop: theme.spacing(2),
+    marginTop: theme.spacer * 2,
     [theme.breakpoints.sm]: {
       marginTop: 'auto'
     }
@@ -61,43 +61,43 @@ const usePaymentsNetworkStyles = createUseStyles(theme => ({
     }
   },
   list: {
-    marginTop: theme.spacing(2),
-    paddingInline: theme.spacing(2)
+    marginTop: theme.spacer * 2,
+    paddingInline: theme.spacer * 2
   },
   listItem: {
     color: theme.palette.gray.main,
-    fontSize: theme.spacing(2),
-    lineHeight: `${theme.spacing(3.5)}px`,
-    paddingBottom: theme.spacing(1)
+    fontSize: theme.spacer * 2,
+    lineHeight: `${theme.spacer * 3.5}px`,
+    paddingBottom: theme.spacer * 1
   },
   section3: {
     backgroundColor: theme.palette.primary.light,
     textAlign: 'center'
   },
   section3Text: {
-    marginTop: theme.spacing(2),
-    marginBottom: theme.spacing(3),
+    marginTop: theme.spacer * 2,
+    marginBottom: theme.spacer * 3,
     [theme.breakpoints.sm]: {
-      marginTop: theme.spacing(3),
-      marginBottom: theme.spacing(10.5)
+      marginTop: theme.spacer * 3,
+      marginBottom: theme.spacer * 10.5
     }
   },
   section4: {
     '& h3': {
       fontSize: '23px',
-      marginBottom: theme.spacing(2.5)
+      marginBottom: theme.spacer * 2.5
     },
     '& $divider': {
       [theme.breakpoints.sm]: {
         width: '50%'
       },
       marginLeft: 'auto',
-      marginTop: theme.spacing(4),
-      marginBottom: theme.spacing(5)
+      marginTop: theme.spacer * 4,
+      marginBottom: theme.spacer * 5
     }
   },
   section4Title: {
-    marginBottom: theme.spacing(2)
+    marginBottom: theme.spacer * 2
   },
   section5: {
     display: 'flex',
@@ -107,8 +107,8 @@ const usePaymentsNetworkStyles = createUseStyles(theme => ({
     }
   },
   section5Text: {
-    paddingTop: theme.spacing(2),
-    paddingBottom: theme.spacing(4)
+    paddingTop: theme.spacer * 2,
+    paddingBottom: theme.spacer * 4
   },
   linksWrapper: {
     display: 'flex',
@@ -119,7 +119,7 @@ const usePaymentsNetworkStyles = createUseStyles(theme => ({
     }
   },
   link: {
-    marginBottom: theme.spacing(2),
+    marginBottom: theme.spacer * 2,
     [theme.breakpoints.sm]: {
       marginBottom: 0
     }
@@ -128,11 +128,11 @@ const usePaymentsNetworkStyles = createUseStyles(theme => ({
     width: '100%',
     height: '1px',
     background: theme.palette.primary.main,
-    marginTop: theme.spacing(4),
-    marginBottom: theme.spacing(3),
+    marginTop: theme.spacer * 4,
+    marginBottom: theme.spacer * 3,
     [theme.breakpoints.sm]: {
-      marginTop: theme.spacing(7),
-      marginBottom: theme.spacing(8)
+      marginTop: theme.spacer * 7,
+      marginBottom: theme.spacer * 8
     }
   },
   onlyDesktop: {

--- a/src/components/project/project.styles.js
+++ b/src/components/project/project.styles.js
@@ -26,10 +26,10 @@ const useProjectStyles = createUseStyles(theme => ({
     }
   },
   section: {
-    padding: `${theme.spacing(8)}px ${theme.spacing(2)}px ${theme.spacing(6)}px ${theme.spacing(2)}px`,
+    padding: `${theme.spacer * 8}px ${theme.spacer * 2}px ${theme.spacer * 6}px ${theme.spacer * 2}px`,
     flexDirection: 'column',
     [theme.breakpoints.sm]: {
-      padding: `${theme.spacing(12)}px ${theme.spacing(9)}px`,
+      padding: `${theme.spacer * 12}px ${theme.spacer * 9}px`,
       flexDirection: 'row'
     }
   },
@@ -40,11 +40,11 @@ const useProjectStyles = createUseStyles(theme => ({
     textAlign: 'center',
     [theme.breakpoints.sm]: {
       flexDirection: 'row',
-      paddingTop: theme.spacing(23),
+      paddingTop: theme.spacer * 23,
       paddingBottom: 'inherit',
       textAlign: 'left',
       '& $col23': {
-        paddingLeft: theme.spacing(20)
+        paddingLeft: theme.spacer * 20
       }
     }
   },
@@ -57,22 +57,22 @@ const useProjectStyles = createUseStyles(theme => ({
   },
   section2: {
     [theme.breakpoints.sm]: {
-      paddingTop: theme.spacing(12),
-      paddingBottom: theme.spacing(9)
+      paddingTop: theme.spacer * 12,
+      paddingBottom: theme.spacer * 9
     }
   },
   title: {
-    marginBottom: theme.spacing(2),
+    marginBottom: theme.spacer * 2,
     [theme.breakpoints.sm]: {
       marginBottom: 'inherit'
     }
   },
   subTitle: {
-    marginTop: theme.spacing(2),
-    marginBottom: theme.spacing(1),
+    marginTop: theme.spacer * 2,
+    marginBottom: theme.spacer * 1,
     [theme.breakpoints.sm]: {
-      marginTop: theme.spacing(0),
-      marginBottom: theme.spacing(2.5)
+      marginTop: theme.spacer * 0,
+      marginBottom: theme.spacer * 2.5
     }
   },
   section3: {
@@ -82,24 +82,24 @@ const useProjectStyles = createUseStyles(theme => ({
     background: theme.palette.primary.main,
     height: '1px',
     marginLeft: 'auto',
-    marginTop: theme.spacing(4),
-    marginBottom: theme.spacing(3),
+    marginTop: theme.spacer * 4,
+    marginBottom: theme.spacer * 3,
     width: '100%',
     [theme.breakpoints.sm]: {
-      marginTop: theme.spacing(4),
-      marginBottom: theme.spacing(5),
+      marginTop: theme.spacer * 4,
+      marginBottom: theme.spacer * 5,
       width: '50%'
     }
   },
   dividerFullWidth: {
     width: '100%',
     [theme.breakpoints.sm]: {
-      marginTop: theme.spacing(10),
-      marginBottom: theme.spacing(8)
+      marginTop: theme.spacer * 10,
+      marginBottom: theme.spacer * 8
     }
   },
   profilesTitle: {
-    marginBottom: theme.spacing(2),
+    marginBottom: theme.spacer * 2,
     [theme.breakpoints.sm]: {
       marginBottom: 0
     }
@@ -110,24 +110,24 @@ const useProjectStyles = createUseStyles(theme => ({
     flexWrap: 'wrap',
     [theme.breakpoints.sm]: {
       flexWrap: 'initial',
-      paddingTop: theme.spacing(7)
+      paddingTop: theme.spacer * 7
     }
   },
   profile: {
     flex: '0 45%',
-    paddingBottom: theme.spacing(3),
+    paddingBottom: theme.spacer * 3,
     [theme.breakpoints.sm]: {
       flex: 'initial',
-      paddingBottom: theme.spacing(0),
-      width: theme.spacing(26.75)
+      paddingBottom: theme.spacer * 0,
+      width: theme.spacer * 26.75
     }
   },
   image: {
     width: '100%'
   },
   name: {
-    marginTop: theme.spacing(2),
-    marginBottom: theme.spacing(1),
+    marginTop: theme.spacer * 2,
+    marginBottom: theme.spacer * 1,
     color: theme.palette.black,
     fontSize: '23px',
     fontWeight: theme.fontWeights.medium,

--- a/src/components/shared/button/button.styles.js
+++ b/src/components/shared/button/button.styles.js
@@ -2,8 +2,8 @@ import { createUseStyles } from 'react-jss'
 
 const useButtonStyles = createUseStyles(theme => ({
   root: {
-    padding: `${theme.spacing(3.25)}px ${theme.spacing(3.5)}px`,
-    lineHeight: `${theme.spacing(2.25)}px`,
+    padding: `${theme.spacer * 3.25}px ${theme.spacer * 3.5}px`,
+    lineHeight: `${theme.spacer * 2.25}px`,
     fontWeight: theme.fontWeights.bold,
     borderRadius: 20,
     cursor: 'pointer',
@@ -23,7 +23,7 @@ const useButtonStyles = createUseStyles(theme => ({
     border: `1px solid ${theme.palette.orange.main}`,
     background: theme.palette.orange.main,
     color: theme.palette.white,
-    marginTop: theme.spacing(5),
+    marginTop: theme.spacer * 5,
     display: 'block',
     '&:hover': {
       border: `1px solid ${theme.palette.orange.dark}`,
@@ -31,7 +31,7 @@ const useButtonStyles = createUseStyles(theme => ({
     }
   },
   secondary: {
-    padding: `${theme.spacing(3.5)}px ${theme.spacing(4)}px`,
+    padding: `${theme.spacer * 3.5}px ${theme.spacer * 4}px`,
     border: `1px solid ${theme.palette.primary.main}`,
     background: theme.palette.white,
     color: theme.palette.gray.main,

--- a/src/components/shared/text-link/text-link.styles.js
+++ b/src/components/shared/text-link/text-link.styles.js
@@ -10,16 +10,16 @@ const useTextLinkStyles = createUseStyles(theme => ({
     }
   },
   linkIcon: {
-    width: theme.spacing(3),
-    height: theme.spacing(3),
-    marginLeft: theme.spacing(2),
+    width: theme.spacer * 3,
+    height: theme.spacer * 3,
+    marginLeft: theme.spacer * 2,
     fill: theme.palette.orange.main,
     '&:hover': {
       fill: theme.palette.orange.dark
     }
   },
   boxLink: {
-    padding: `${theme.spacing(4)}px ${theme.spacing(5)}px`,
+    padding: `${theme.spacer * 4}px ${theme.spacer * 5}px`,
     borderRadius: 20,
     backgroundColor: theme.palette.primary.light,
     color: theme.palette.gray.main,
@@ -27,20 +27,20 @@ const useTextLinkStyles = createUseStyles(theme => ({
     alignItems: 'center',
     justifyContent: 'space-between',
     lineHeight: '29px',
-    height: theme.spacing(16),
-    marginTop: theme.spacing(0),
-    marginBottom: theme.spacing(2),
+    height: theme.spacer * 16,
+    marginTop: theme.spacer * 0,
+    marginBottom: theme.spacer * 2,
     [theme.breakpoints.sm]: {
-      marginTop: theme.spacing(8),
-      marginBottom: theme.spacing(9)
+      marginTop: theme.spacer * 8,
+      marginBottom: theme.spacer * 9
     },
     '&:hover': {
       backgroundColor: theme.palette.gray.dark
     }
   },
   boxLinkText: {
-    width: theme.spacing(17.5),
-    paddingRight: theme.spacing(2)
+    width: theme.spacer * 17.5,
+    paddingRight: theme.spacer * 2
   }
 }))
 

--- a/src/components/shared/title/title.styles.js
+++ b/src/components/shared/title/title.styles.js
@@ -3,8 +3,8 @@ import { createUseStyles } from 'react-jss'
 const useTitleStyles = createUseStyles(theme => ({
   title: {
     fontWeight: theme.fontWeights.bold,
-    fontSize: theme.spacing(4.25),
-    lineHeight: `${theme.spacing(5.25)}px`,
+    fontSize: theme.spacer * 4.25,
+    lineHeight: `${theme.spacer * 5.25}px`,
     fontStretch: 'normal',
     fontStyle: 'normal',
     letterSpacing: 'normal',
@@ -13,16 +13,16 @@ const useTitleStyles = createUseStyles(theme => ({
   titleSecondary: {
     color: theme.palette.black,
     fontWeight: theme.fontWeights.medium,
-    fontSize: theme.spacing(2.5),
-    lineHeight: `${theme.spacing(4)}px`,
-    marginBottom: theme.spacing(1),
+    fontSize: theme.spacer * 2.5,
+    lineHeight: `${theme.spacer * 4}px`,
+    marginBottom: theme.spacer * 1,
     [theme.breakpoints.sm]: {
-      fontSize: theme.spacing(3) - 1,
-      marginBottom: theme.spacing(2.5)
+      fontSize: theme.spacer * 3 - 1,
+      marginBottom: theme.spacer * 2.5
     }
   },
   titleTertiary: {
-    fontSize: theme.spacing(3),
+    fontSize: theme.spacer * 3,
     lineHeight: 'inherit'
   }
 }))

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -1,4 +1,4 @@
-export const theme = {
+module.exports = {
   palette: {
     primary: {
       light: '#f6f7fa',
@@ -29,5 +29,5 @@ export const theme = {
     lg: '@media (min-width: 992px)',
     xl: '@media (min-width: 1200px)'
   },
-  spacing: (value) => value * 8
+  spacer: 8
 }


### PR DESCRIPTION
This PR fixes the JSS when doing SSR as we need to serialize and keep a cache of all the injected stylesheets in the DOM. I found an official Gatsby plugin that's already doing it, so this PR adds the plugin and replaces the `theme.spacing` function as it isn't serializable with just a property `spacer`, which is serializable and can be used when building using SSR.