### PR TITLE
Remove support for different env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,4 @@ node_modules/
 public/
 
 # Env
-.env*
-!.env.example
+.env

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,8 +1,6 @@
 const theme = require('./src/styles/theme.js')
 
-require('dotenv').config({
-  path: `.env.${process.env.NODE_ENV || 'development'}`
-})
+require('dotenv').config()
 
 module.exports = {
   siteMetadata: {


### PR DESCRIPTION
Now we just support one `.env` file. The production env vars are defined as secrets in this repo so we don't need to use more than one `.env` file anymore.